### PR TITLE
Selenium session teardown

### DIFF
--- a/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
+++ b/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
@@ -94,7 +94,6 @@ public class SeleniumDriver {
 
   public static void tearDown() {
     if (chromeDriver != null) {
-      chromeDriver.close();
       chromeDriver.quit();
     }
     seleniumDriver = null;

--- a/src/main/java/stepsdesign/AfterActions.java
+++ b/src/main/java/stepsdesign/AfterActions.java
@@ -30,9 +30,13 @@ import org.openqa.selenium.WebDriver;
 public class AfterActions {
 
   @AfterStep
-  public static void tearDown(Scenario scenario) {
-    WebDriver driver = SeleniumDriver.getDriver();
-    byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
-    scenario.embed(screenshotBytes, "image/png");
+  public static void takeScreenshot(Scenario scenario) {
+    try {
+      WebDriver driver = SeleniumDriver.getDriver();
+      byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+      scenario.embed(screenshotBytes, "image/png");
+    } catch (Exception e) {
+      scenario.write("Exception in capturing screenshot : " + e.getMessage() + " : " + e);
+    }
   }
 }

--- a/src/main/java/stepsdesign/BeforeActions.java
+++ b/src/main/java/stepsdesign/BeforeActions.java
@@ -32,11 +32,16 @@ import java.nio.file.Paths;
 public class BeforeActions {
   public static Scenario scenario;
   public static File myObj;
+  public static boolean beforeAllFlag = true;
 
   @Before(order = 0)
   public void setUp(Scenario scenario) throws IOException {
+    if (beforeAllFlag) {
+      Runtime.getRuntime().addShutdownHook(new Thread(SeleniumDriver::tearDown));
+      beforeAllFlag = false;
+      SeleniumDriver.setUpDriver();
+    }
     this.scenario = scenario;
-    SeleniumDriver.setUpDriver();
     String[] tab = scenario.getId().split("/");
     int rawFeatureNameLength = tab.length;
     String featureName = tab[rawFeatureNameLength - 1].split(":")[0];


### PR DESCRIPTION
@itsankit-google @rmstar  Closing selenium driver session after all scenarios. 
Cucumber does not have @BeforeAll and @AfterAll tags. This is workaround using Runtime.getRuntime().addShutdownHook in @Before. 
