### PR TITLE
Divide SeleniumHelper class in relevant helper classes

### DIFF
--- a/src/main/java/io/cdap/e2e/pages/actions/CdfBigQueryPropertiesActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfBigQueryPropertiesActions.java
@@ -18,6 +18,7 @@ package io.cdap.e2e.pages.actions;
 
 import io.cdap.e2e.pages.locators.CdfBigQueryPropertiesLocators;
 import io.cdap.e2e.pages.locators.CdfStudioLocators;
+import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.PluginPropertyUtils;
 import io.cdap.e2e.utils.SeleniumHelper;
 
@@ -39,15 +40,14 @@ public class CdfBigQueryPropertiesActions {
   }
 
   /**
-   * @deprecated
-   * Call individual actions as per test scenario in step design file.
+   * @deprecated Call individual actions as per test scenario in step design file.
    */
   @Deprecated
   public static void enterBigQueryProperties(String tableProp) throws InterruptedException, IOException {
     CdfStudioLocators.bigQueryProperties.click();
     CdfBigQueryPropertiesLocators.bigQueryReferenceName.sendKeys(AUTOMATION_TEST);
     SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.projectID,
-                                       PluginPropertyUtils.pluginProp(PROJECT_ID));
+      PluginPropertyUtils.pluginProp(PROJECT_ID));
     CdfBigQueryPropertiesLocators.datasetProjectID.sendKeys(PluginPropertyUtils.pluginProp(PROJECT_ID));
     CdfBigQueryPropertiesLocators.bigQueryDataSet.sendKeys(PluginPropertyUtils.pluginProp(DATASET));
     CdfBigQueryPropertiesLocators.bigQueryTable.sendKeys(tableProp);
@@ -62,7 +62,7 @@ public class CdfBigQueryPropertiesActions {
   }
 
   public static void enterFilePath(String path) throws InterruptedException, IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.serviceFilePath, path);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.serviceFilePath, path);
   }
 
   public static void enterBigQueryReferenceName(String referenceName) {
@@ -70,11 +70,11 @@ public class CdfBigQueryPropertiesActions {
   }
 
   public static void enterProjectId(String projectId) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.projectID, projectId);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.projectID, projectId);
   }
 
   public static void enterDatasetProjectId(String projectId) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.datasetProjectID, projectId);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.datasetProjectID, projectId);
   }
 
   public static void enterBigQueryDataset(String dataset) {
@@ -94,15 +94,15 @@ public class CdfBigQueryPropertiesActions {
   }
 
   public static void enterPartitionStartDate(String partitionStartDate) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.partitionStartDate, partitionStartDate);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.partitionStartDate, partitionStartDate);
   }
 
   public static void enterPartitionEndDate(String partitionEndDate) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.partitionEndDate, partitionEndDate);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.partitionEndDate, partitionEndDate);
   }
 
   public static void enterFilter(String filter) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.filter, filter);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.filter, filter);
   }
 
   public static void getSchema() {
@@ -114,20 +114,19 @@ public class CdfBigQueryPropertiesActions {
   }
 
   public static void viewMaterializationProject(String projectId) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.viewMaterializationProject, projectId);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.viewMaterializationProject, projectId);
   }
 
   public static void viewMaterializationDataset(String dataset) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.viewMaterializationDataset, dataset);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.viewMaterializationDataset, dataset);
   }
 
   public static void enterTemporaryBucketName(String bucket) throws IOException {
-    SeleniumHelper.replaceElementValue(CdfBigQueryPropertiesLocators.temporaryBucketName, bucket);
+    ElementHelper.replaceElementValue(CdfBigQueryPropertiesLocators.temporaryBucketName, bucket);
   }
 
   /**
-   * @deprecated
-   * Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginPreviewData(String)}
+   * @deprecated Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginPreviewData(String)}
    * or {@link io.cdap.e2e.utils.CdfHelper#openSourcePluginPreviewData(String)} as per plugin type.
    */
   @Deprecated

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfGcsActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfGcsActions.java
@@ -17,12 +17,14 @@
 package io.cdap.e2e.pages.actions;
 
 import io.cdap.e2e.pages.locators.CdfGCSLocators;
+import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.PluginPropertyUtils;
 import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.SeleniumHelper;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
@@ -49,7 +51,7 @@ public class CdfGcsActions {
   }
 
   public static void enterProjectId() throws IOException {
-    SeleniumHelper.replaceElementValue(CdfGCSLocators.projectID, PluginPropertyUtils.pluginProp(PROJECT_ID));
+    ElementHelper.replaceElementValue(CdfGCSLocators.projectID, PluginPropertyUtils.pluginProp(PROJECT_ID));
   }
 
   public static void getGcsBucket(String bucket) {
@@ -68,8 +70,7 @@ public class CdfGcsActions {
   }
 
   /**
-   * @deprecated
-   * Use {@link CdfGcsActions#enterSampleSize(String)}
+   * @deprecated Use {@link CdfGcsActions#enterSampleSize(String)}
    */
   @Deprecated
   public static void enterSamplesize() {
@@ -81,8 +82,7 @@ public class CdfGcsActions {
   }
 
   /**
-   * @deprecated
-   * Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginProperties(String)}
+   * @deprecated Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginProperties(String)}
    * or {@link io.cdap.e2e.utils.CdfHelper#openSourcePluginProperties(String)} as per plugin type.
    */
   @Deprecated
@@ -99,8 +99,7 @@ public class CdfGcsActions {
   }
 
   /**
-   * @deprecated
-   * Use {@link CdfGcsActions#enterDelimiterField(String)}
+   * @deprecated Use {@link CdfGcsActions#enterDelimiterField(String)}
    */
   @Deprecated
   public static void delimiter() throws IOException {
@@ -109,13 +108,12 @@ public class CdfGcsActions {
 
   public static void selectFormat(String formatType) throws InterruptedException {
     CdfGCSLocators.format.click();
-    SeleniumHelper.waitAndClick(SeleniumDriver.getDriver().findElement(By.xpath(
+    ElementHelper.clickOnElement(SeleniumDriver.getDriver().findElement(By.xpath(
       "//li[@data-value='" + formatType + "']")));
   }
 
   /**
-   * @deprecated
-   * Use {@link io.cdap.e2e.utils.CdfHelper#validateSchema(Map)}
+   * @deprecated Use {@link io.cdap.e2e.utils.CdfHelper#validateSchema(Map)}
    */
   @Deprecated
   public static void validateSchema() {
@@ -162,7 +160,7 @@ public class CdfGcsActions {
 
   public static void clickOverrideDataType(String dataType) {
     CdfGCSLocators.overrideDataType.click();
-    SeleniumHelper.waitAndClick(
+    ElementHelper.clickOnElement(
       SeleniumDriver.getDriver().findElement(By.xpath("//*[@data-value='" + dataType + "']")));
   }
 
@@ -171,20 +169,20 @@ public class CdfGcsActions {
   }
 
   /**
-   * @deprecated
-   * Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginPreviewData(String)}
+   * @deprecated Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginPreviewData(String)}
    * or {@link io.cdap.e2e.utils.CdfHelper#openSourcePluginPreviewData(String)} as per plugin type.
    */
   @Deprecated
   public static void clickPreviewData() {
     SeleniumHelper.waitAndClick(CdfGCSLocators.gcsPreviewData);
   }
+
   public static void enterSampleSize(String sampleSize) {
-    SeleniumHelper.replaceElementValue(CdfGCSLocators.samplesize, sampleSize);
+    ElementHelper.replaceElementValue(CdfGCSLocators.samplesize, sampleSize);
   }
 
   public static void enterPathSuffix(String pathSuffix) {
-    SeleniumHelper.replaceElementValue(CdfGCSLocators.pathSuffix, pathSuffix);
+    ElementHelper.replaceElementValue(CdfGCSLocators.pathSuffix, pathSuffix);
   }
 
   public static void toggleWriteHeader() {
@@ -192,12 +190,12 @@ public class CdfGcsActions {
   }
 
   public static void enterLocation(String location) {
-    SeleniumHelper.replaceElementValue(CdfGCSLocators.location, location);
+    ElementHelper.replaceElementValue(CdfGCSLocators.location, location);
   }
 
   public static void selectContentType(String contentType) {
     CdfGCSLocators.contentType.click();
-    SeleniumHelper.waitAndClick(SeleniumDriver.getDriver().findElement(By.xpath(
+    ElementHelper.clickOnElement(SeleniumDriver.getDriver().findElement(By.xpath(
       "//li[@data-value='" + contentType + "']")));
   }
 

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfHomeActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfHomeActions.java
@@ -17,15 +17,10 @@
 package io.cdap.e2e.pages.actions;
 
 import io.cdap.e2e.pages.locators.CdfHomeLocators;
-import io.cdap.e2e.utils.SeleniumDriver;
+import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.SeleniumHelper;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.cdap.e2e.utils.ConstantsUtil.JS_CLICK;
-import static io.cdap.e2e.utils.ConstantsUtil.PASS_CASE;
 
 /**
  * Represents CdfHomeActions
@@ -39,9 +34,6 @@ public class CdfHomeActions {
   }
 
   public static void clickStudio() {
-    JavascriptExecutor js = (JavascriptExecutor) SeleniumDriver.getDriver();
-    WebElement element = CdfHomeLocators.studio;
-    js.executeScript(JS_CLICK, element);
-    logger.info(PASS_CASE);
+    ElementHelper.clickOnElement(CdfHomeLocators.studio);
   }
 }

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfLogActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfLogActions.java
@@ -17,6 +17,7 @@
 package io.cdap.e2e.pages.actions;
 
 import io.cdap.e2e.pages.locators.CdfLogLocators;
+import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.SeleniumHelper;
 
 /**
@@ -30,11 +31,11 @@ public class CdfLogActions {
   }
 
   public static void validateErrorPopupLog() throws InterruptedException {
-    SeleniumHelper.waitAndClick(cdfLogLocators.errorMessagePopup);
+    ElementHelper.clickOnElement(cdfLogLocators.errorMessagePopup);
   }
 
   public static void validateErrorPopupLog(String error) throws InterruptedException {
-    SeleniumHelper.waitAndClick(cdfLogLocators.errorMessagePopup);
+    ElementHelper.clickOnElement(cdfLogLocators.errorMessagePopup);
   }
 
   public static void dismissPopup() {

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
@@ -17,8 +17,11 @@
 package io.cdap.e2e.pages.actions;
 
 import io.cdap.e2e.pages.locators.CdfPipelineRunLocators;
+import io.cdap.e2e.utils.ConstantsUtil;
+import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.SeleniumHelper;
+import io.cdap.e2e.utils.WaitHelper;
 import org.junit.Assert;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -27,10 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-
-import static io.cdap.e2e.utils.ConstantsUtil.COLOR;
-import static io.cdap.e2e.utils.ConstantsUtil.ONE;
-import static io.cdap.e2e.utils.ConstantsUtil.WAIT_TIME;
 
 /**
  * Represents CdfPipelineRunAction
@@ -44,11 +43,11 @@ public class CdfPipelineRunAction {
   }
 
   public static void runClick() throws InterruptedException {
-    SeleniumHelper.waitAndClick(cdfPipelineRunLocators.run, WAIT_TIME);
+    ElementHelper.clickOnElement(cdfPipelineRunLocators.run);
   }
 
   public static String runPipelineStatus() {
-    return cdfPipelineRunLocators.runPipelineStatus.getAttribute(COLOR);
+    return cdfPipelineRunLocators.runPipelineStatus.getAttribute(ConstantsUtil.COLOR);
   }
 
   public static Boolean isRunning() {
@@ -77,7 +76,7 @@ public class CdfPipelineRunAction {
     int attempts = 0;
     while (attempts < 5) {
       try {
-        SeleniumHelper.waitElementIsVisible(cdfPipelineRunLocators.logsArrow);
+        WaitHelper.waitForElementToBeDisplayed(cdfPipelineRunLocators.logsArrow);
         cdfPipelineRunLocators.logsArrow.click();
         break;
       } catch (StaleElementReferenceException e) {
@@ -90,7 +89,7 @@ public class CdfPipelineRunAction {
     cdfPipelineRunLocators.viewRawLogs.click();
     String parent = SeleniumDriver.getDriver().getWindowHandle();
     ArrayList<String> tabs2 = new ArrayList<>(SeleniumDriver.getDriver().getWindowHandles());
-    SeleniumDriver.getDriver().switchTo().window(tabs2.get(ONE));
+    SeleniumDriver.getDriver().switchTo().window(tabs2.get(ConstantsUtil.ONE));
     String logs = CdfPipelineRunLocators.logsTextbox.getText();
     Assert.assertNotNull(logs);
     SeleniumDriver.getDriver().close();
@@ -101,5 +100,4 @@ public class CdfPipelineRunAction {
   public static void clickDeployedConfigRunButton() {
     CdfPipelineRunLocators.deployedConfigRunButton.click();
   }
-
 }

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
@@ -17,28 +17,49 @@
 package io.cdap.e2e.pages.actions;
 
 import io.cdap.e2e.pages.locators.CdfStudioLocators;
-import io.cdap.e2e.utils.ConstantsUtil;
+import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.SeleniumHelper;
+import io.cdap.e2e.utils.WaitHelper;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
-
-import static io.cdap.e2e.utils.ConstantsUtil.JS_CLICK;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Represents CdfStudioActions
+ * Represents Cdf Studio page Actions
  */
 public class CdfStudioActions {
+  private static final Logger logger = LoggerFactory.getLogger(CdfStudioActions.class);
   public static CdfStudioLocators cdfStudioLocators;
 
   static {
     cdfStudioLocators = SeleniumHelper.getPropertiesLocators(CdfStudioLocators.class);
   }
 
+  public static void selectDataPipelineType(String option) {
+    ElementHelper.clickOnElement(CdfStudioLocators.dataPipelineTypeDropdown);
+    /* TODO: Replace JsExecutor click with normal click: https://cdap.atlassian.net/browse/CDAP-18885 */
+    ElementHelper.clickOnElementUsingJsExecutor(CdfStudioLocators.locateDataPipelineTypeDropdownOption(option));
+  }
+
+  public static void expandPluginGroupIfNotAlreadyExpanded(String pluginGroupName) {
+    ElementHelper.clickIfDisplayed(CdfStudioLocators.locatePluginGroupCollapsed(pluginGroupName));
+    WaitHelper.waitForElementToBeDisplayed(CdfStudioLocators.locatePluginGroupExpanded(pluginGroupName));
+  }
+
+  public static void selectPluginFromList(String pluginName) {
+    logger.info("Click on plugin from the list: " + pluginName);
+    ElementHelper.clickOnElement(CdfStudioLocators.locatePluginNameInList(pluginName));
+  }
+
+  public static void navigateToPluginPropertiesPage(String pluginName) {
+    ElementHelper.hoverOverElement(CdfStudioLocators.locatePluginNodeInCanvas(pluginName));
+    ElementHelper.clickOnElement(CdfStudioLocators.locatePluginPropertiesButton(pluginName));
+  }
+
   /**
-   * @deprecated
-   * Use {@link io.cdap.e2e.utils.CdfHelper#selectSourcePlugin(String)}
+   * @deprecated Use {@link io.cdap.e2e.utils.CdfHelper#selectSourcePlugin(String)}
    */
   @Deprecated
   public static void selectGCS() throws InterruptedException {
@@ -47,8 +68,7 @@ public class CdfStudioActions {
   }
 
   /**
-   * @deprecated
-   * Use {@link io.cdap.e2e.utils.CdfHelper#selectSourcePlugin(String)}
+   * @deprecated Use {@link io.cdap.e2e.utils.CdfHelper#selectSourcePlugin(String)}
    */
   @Deprecated
   public static void clickSource() {
@@ -56,8 +76,8 @@ public class CdfStudioActions {
   }
 
   /**
-   * @deprecated
-   * Use {@link CdfStudioActions#clickSink()} and {@link io.cdap.e2e.utils.CdfHelper#selectSinkPlugin(String)}
+   * @deprecated Use {@link CdfStudioActions#clickSink()} and
+   * {@link io.cdap.e2e.utils.CdfHelper#selectSinkPlugin(String)}
    */
   @Deprecated
   public static void sinkBigQuery() {
@@ -87,8 +107,7 @@ public class CdfStudioActions {
   }
 
   public static void pipelineDeploy() {
-    JavascriptExecutor jse = (JavascriptExecutor) SeleniumDriver.getDriver();
-    jse.executeScript(JS_CLICK, CdfStudioLocators.pipelineDeploy);
+    ElementHelper.clickOnElement(CdfStudioLocators.pipelineDeploy);
   }
 
   public static String bannerErrorMessage() {
@@ -104,8 +123,7 @@ public class CdfStudioActions {
   }
 
   /**
-   * @deprecated
-   * Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginProperties(String)}
+   * @deprecated Use either {@link io.cdap.e2e.utils.CdfHelper#openSinkPluginProperties(String)}
    * or {@link io.cdap.e2e.utils.CdfHelper#openSourcePluginProperties(String)} as per plugin type.
    */
   @Deprecated
@@ -115,11 +133,10 @@ public class CdfStudioActions {
   }
 
   /**
-   * @deprecated
-   * Use {@link io.cdap.e2e.utils.CdfHelper#connectSourceAndSink(String, String)}
+   * @deprecated Use {@link io.cdap.e2e.utils.CdfHelper#connectSourceAndSink(String, String)}
    */
   @Deprecated
-  public static void  connectSourceAndSink(String source, String sink) {
+  public static void connectSourceAndSink(String source, String sink) {
     SeleniumHelper.waitElementIsVisible(SeleniumDriver.getDriver().findElement(
       By.xpath("//*[contains(@title,'" + sink + "')]")));
     SeleniumHelper.dragAndDrop(
@@ -128,8 +145,7 @@ public class CdfStudioActions {
   }
 
   /**
-   * @deprecated
-   * Use {@link io.cdap.e2e.utils.CdfHelper#selectSourcePlugin(String)}
+   * @deprecated Use {@link io.cdap.e2e.utils.CdfHelper#selectSourcePlugin(String)}
    */
   @Deprecated
   public static void selectBQ() throws InterruptedException {
@@ -137,12 +153,12 @@ public class CdfStudioActions {
   }
 
   public static void clickCloseButton() {
-    SeleniumHelper.waitAndClick(CdfStudioLocators.closeButton);
+    ElementHelper.clickOnElement(CdfStudioLocators.closeButton);
   }
 
   /**
-   * @deprecated
-   * Use {@link CdfStudioActions#clickSink()} and {@link io.cdap.e2e.utils.CdfHelper#selectSinkPlugin(String)}
+   * @deprecated Use {@link CdfStudioActions#clickSink()} and
+   * {@link io.cdap.e2e.utils.CdfHelper#selectSinkPlugin(String)}
    */
   @Deprecated
   public static void sinkGcs() {

--- a/src/main/java/io/cdap/e2e/pages/locators/CdfStudioLocators.java
+++ b/src/main/java/io/cdap/e2e/pages/locators/CdfStudioLocators.java
@@ -25,9 +25,12 @@ import org.openqa.selenium.support.How;
 import java.util.List;
 
 /**
- * Represents CdfStudioLocators
+ * Represents Cdf Studio Page Locators
  */
 public class CdfStudioLocators {
+  @FindBy(how = How.XPATH, using = "//div[contains(@class, 'left-top-section')]//select")
+  public static WebElement dataPipelineTypeDropdown;
+
   @FindBy(how = How.XPATH, using = "//*[@data-cy=\"plugin-GCSFile-batchsource\"]")
   public static WebElement source;
 
@@ -144,5 +147,38 @@ public class CdfStudioLocators {
 
   public static WebElement macroInput(String pluginProperty) {
     return SeleniumDriver.getDriver().findElement(By.xpath("//input[@data-cy='" + pluginProperty + "']"));
+  }
+
+  public static WebElement locateDataPipelineTypeDropdownOption(String option) {
+    String xpath = "//div[contains(@class, 'left-top-section')]//select//option[contains(@label, '" + option + "')]";
+    return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+  }
+
+  public static WebElement locatePluginGroupExpanded(String pluginGroupName) {
+    String xpath = "//span[normalize-space(text())='" + pluginGroupName + "']" +
+      "/preceding-sibling::span[contains(@class, 'caret-down')]";
+    return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+  }
+
+  public static WebElement locatePluginGroupCollapsed(String pluginGroupName) {
+    String xpath = "//span[normalize-space(text())='" + pluginGroupName + "']" +
+      "/preceding-sibling::span[contains(@class, 'caret-right')]";
+    return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+  }
+
+  public static WebElement locatePluginNameInList(String pluginName) {
+    String xpath = "//div[contains(@class, 'plugin-name')][normalize-space(text()) = '" + pluginName + "']";
+    return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+  }
+
+  public static WebElement locatePluginNodeInCanvas(String pluginName) {
+    String xpath = "//div[contains(@class, 'node-name')][@title= '" + pluginName + "']";
+    return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+  }
+
+  public static WebElement locatePluginPropertiesButton(String pluginName) {
+    String xpath = "//div[contains(@class, 'node-name')][@title= '" + pluginName + "']" +
+      "/following-sibling::button[@data-cy='node-properties-btn']";
+    return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
   }
 }

--- a/src/main/java/io/cdap/e2e/utils/AssertionHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/AssertionHelper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.e2e.utils;
+
+import org.junit.Assert;
+import org.openqa.selenium.WebElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Assertion helper
+ */
+public class AssertionHelper {
+  private static final Logger logger = LoggerFactory.getLogger(AssertionHelper.class);
+
+  public static void verifyElementDisplayed(WebElement element) {
+    logger.info("Verifying that the element: " + element + " is displayed");
+    Assert.assertTrue(element.isDisplayed());
+  }
+
+  public static void verifyElementDisplayed(WebElement element, String message) {
+    logger.info("Verifying that the element: " + element + " is displayed");
+    Assert.assertTrue(message, element.isDisplayed());
+  }
+
+  public static void verifyElementContainsText(WebElement element, String expectedText) {
+    String actualText = element.getText();
+
+    logger.info("Verifying that the element: " + element + " has text: " + expectedText);
+    logger.info("Actual text: " + actualText);
+    Assert.assertTrue(actualText.contains(expectedText));
+  }
+}

--- a/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
+++ b/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
@@ -27,12 +27,14 @@ public class ConstantsUtil {
   public static final String VALUE = "value";
   public static final String OFFSET = "offset";
   public static final String JS_CLICK = "arguments[0].click();";
+  public static final String JS_SCROLL_INTO_VIEW = "arguments[0].scrollIntoView(true);";
   public static final String COLOR = "color";
   public static final String GUSERNAME = "gLoginUsername";
   public static final String GPAZWRD = "gPassword";
   public static final String CDFURL = "cdfurl";
+  public static final String BATCH = "Batch";
+  public static final String REALTIME = "Realtime";
   public static final int ONE = 1;
-  public static final int WAIT_TIME = 60;
   public static final String PASS_CASE = "First case passed";
   public static final String ERROR_MSG_COLOR = "#a40403";
   public static final String ERROR_MSG_MANDATORY = "Required property 'PROPERTY' has no value.";
@@ -40,4 +42,25 @@ public class ConstantsUtil {
   public static final String DEFAULT_ERROR_PROPERTIES_FILE = "errorMessage.properties";
   public static final String VALIDATION_SUCCESS_MESSAGE = "validationSuccessMessage";
   public static final String VALIDATION_ERROR_MESSAGE = "validationErrorMessage";
+  /* TODO: Remove FIRST_PLUGIN_IN_LIST constant once https://cdap.atlassian.net/browse/CDAP-18862 is fixed */
+  public static final String FIRST_PLUGIN_IN_LIST = "BigQuery";
+  /**
+   * IMPLICIT_TIMEOUT_SECONDS: Selenium driver will wait and retry for the specified time before failing.
+   * It should be on the lower side as actions anticipating larger waits should be handled with pre-defined explicit
+   * waits.
+   * For external waits examples, refer: {@link WaitHelper}
+   */
+  public static final int IMPLICIT_TIMEOUT_SECONDS = 30;
+  /**
+   * DEFAULT_TIMEOUT_SECONDS: To be used in external wait helpers defined in {@link WaitHelper}
+   */
+  public static final int DEFAULT_TIMEOUT_SECONDS = 60;
+  /**
+   * PAGE_LOAD_TIMEOUT_SECONDS: To be used as Selenium driver's default page load timeout
+   */
+  public static final int PAGE_LOAD_TIMEOUT_SECONDS = 50;
+  /**
+   * SMALL_TIMEOUT_SECONDS: To be used as a small static wait (only if needed)
+   */
+  public static final int SMALL_TIMEOUT_SECONDS = 5;
 }

--- a/src/main/java/io/cdap/e2e/utils/ElementHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/ElementHelper.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.e2e.utils;
+
+import org.junit.Assert;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Element helper
+ */
+public class ElementHelper {
+  private static final Logger logger = LoggerFactory.getLogger(ElementHelper.class);
+  private static final JavascriptExecutor js = (JavascriptExecutor) SeleniumDriver.getDriver();
+  private static final Actions actions = new Actions(SeleniumDriver.getDriver());
+
+  public static void scrollToElement(WebElement element) {
+    logger.info("Scrolling to the element: " + element);
+    actions.moveToElement(element).perform();
+  }
+
+  /**
+   * Scrolling to get the element in view using the Javascript Executor.
+   * It should only be used if necessary, as it does not replicate how a user would interact with the page.
+   * @param element
+   */
+  public static void scrollToElementUsingJsExecutor(WebElement element) {
+    logger.info("Scrolling to the element: " + element + " using the JsExecutor");
+    js.executeScript(ConstantsUtil.JS_SCROLL_INTO_VIEW, element);
+  }
+
+  /**
+   * Clicking on an element using the Javascript Executor.
+   * It should only be used if necessary, as it does not replicate how a user would interact with the page.
+   * @param element
+   */
+  public static void clickOnElementUsingJsExecutor(WebElement element) {
+    logger.info("Click on the element using Javascript Executor: " + element);
+    js.executeScript(ConstantsUtil.JS_CLICK, element);
+  }
+
+  public static void clickOnElement(WebElement element) {
+    WaitHelper.waitForElementToBeClickable(element);
+    scrollToElement(element);
+    logger.info("Click on the element: " + element);
+    element.click();
+  }
+
+  public static void clickOnElement(WebElement element, long timeoutInSeconds) {
+    WaitHelper.waitForElementToBeClickable(element, timeoutInSeconds);
+    scrollToElement(element);
+    logger.info("Click on the element: " + element);
+    element.click();
+  }
+
+  public static void clickIfDisplayed(WebElement element, long timeoutInSeconds) {
+    if (isElementDisplayed(element, timeoutInSeconds)) {
+      clickOnElement(element, timeoutInSeconds);
+    }
+  }
+
+  public static void clickIfDisplayed(WebElement element) {
+    clickIfDisplayed(element, ConstantsUtil.SMALL_TIMEOUT_SECONDS);
+  }
+
+  public static void sendKeys(WebElement element, String keys) {
+    WaitHelper.waitForElementToBeDisplayed(element);
+    scrollToElement(element);
+    logger.info("Send keys to element: " + element);
+    element.sendKeys(keys);
+  }
+
+  public static void hoverOverElement(WebElement element) {
+    WaitHelper.waitForElementToBeDisplayed(element);
+    scrollToElement(element);
+    logger.info("Hovering over the element: " + element);
+    actions.moveToElement(element).build().perform();
+  }
+
+  public static void clearElementValue(WebElement element, int limit) {
+    WaitHelper.waitForElementToBeDisplayed(element);
+    scrollToElement(element);
+    logger.info("Clearing WebElement: " + element);
+    element.click();
+    element.clear();
+
+    for (int i = 0; i < limit; i++) {
+      if (element.getAttribute("value").equals("")) {
+        return;
+      }
+
+      element.sendKeys(Keys.BACK_SPACE);
+    }
+
+    Assert.fail("Element's current value is not cleared - " + element + " - "
+      + "Current value :" + element.getAttribute("value"));
+  }
+
+  public static void clearElementValue(WebElement element) {
+    clearElementValue(element, 1024);
+  }
+
+  /**
+   * Replacing the value of the text box when clear is not working
+   * https://github.com/SeleniumHQ/selenium/issues/6741
+   */
+  public static void replaceElementValue(WebElement element, String value) {
+    replaceElementValue(element, value, 1024);
+  }
+
+  public static void replaceElementValue(WebElement element, String value, int limit) {
+    clearElementValue(element, limit);
+    element.sendKeys(value);
+  }
+
+  public static void dragAndDrop(WebElement source, WebElement target) {
+    WaitHelper.waitForElementToBeDisplayed(source);
+    WaitHelper.waitForElementToBeDisplayed(target);
+    logger.info("Drag and drop the element from source: " + source + " to target: " + target);
+    actions.dragAndDrop(source, target).build().perform();
+  }
+
+  /**
+   * Performs click-and-hold at the location of the element, moves by a given offset, then releases the mouse.
+   */
+  public static void dragAndDropByOffset(WebElement element, int xOffset, int yOffset) {
+    WaitHelper.waitForElementToBeDisplayed(element);
+    logger.info("Drag and drop of element: " + element + " with xOffset: " + xOffset + " and yOffset: " + yOffset);
+    actions.dragAndDropBy(element, xOffset, yOffset).build().perform();
+  }
+
+  public static boolean isElementDisplayed(WebElement element) {
+    logger.info("Check if element: " + element + " is displayed.");
+    try {
+      boolean isPresent = element.isDisplayed();
+      return isPresent;
+    } catch (NoSuchElementException e) {
+      return false;
+    }
+  }
+
+  public static boolean isElementDisplayed(WebElement element, long timeoutInSeconds) {
+    WaitHelper.waitForElementToBeDisplayed(element, timeoutInSeconds);
+    return isElementDisplayed(element);
+  }
+}

--- a/src/main/java/io/cdap/e2e/utils/PageHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/PageHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.e2e.utils;
+
+import org.openqa.selenium.NoAlertPresentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Page helper
+ */
+public class PageHelper {
+  private static final Logger logger = LoggerFactory.getLogger(PageHelper.class);
+
+  public static void acceptAlertIfPresent() {
+    try {
+      logger.info("Accepting alert if present");
+      SeleniumDriver.getDriver().switchTo().alert().accept();
+    } catch (NoAlertPresentException exception) {
+      logger.info("No alert present");
+    }
+  }
+
+  public static void dismissAlertIfPresent() {
+    try {
+      logger.info("Dismiss alert if present");
+      SeleniumDriver.getDriver().switchTo().alert().dismiss();
+    } catch (NoAlertPresentException exception) {
+      logger.info("No alert present");
+    }
+  }
+}

--- a/src/main/java/io/cdap/e2e/utils/SeleniumHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/SeleniumHelper.java
@@ -38,10 +38,9 @@ import java.util.Properties;
  */
 public class SeleniumHelper {
 
-  static String path;
   private static final Logger logger = LoggerFactory.getLogger(SeleniumHelper.class);
-  private static final long DEFAULT_TIMEOUT = 30;
-  private static Properties connectProperties = new Properties();
+  static String path;
+  private static final Properties connectProperties = new Properties();
 
   static {
     try {
@@ -77,94 +76,112 @@ public class SeleniumHelper {
     }
   }
 
-  public static boolean isElementPresent(WebElement webElement) {
-    try {
-      boolean isPresent = webElement.isDisplayed();
-      return isPresent;
-    } catch (NoSuchElementException e) {
-      return false;
-    }
+  public static String readParameters(String property) throws IOException {
+    return connectProperties.getProperty(property);
   }
 
+  public static <T> T getPropertiesLocators(Class<T> className) {
+    return PageFactory.initElements(SeleniumDriver.getDriver(), className);
+  }
+
+  /**
+   * @deprecated Use {@link ElementHelper#isElementDisplayed(WebElement)}
+   */
+  @Deprecated
+  public static boolean isElementPresent(WebElement webElement) {
+    return ElementHelper.isElementDisplayed(webElement);
+  }
+
+  /**
+   * @deprecated Use {@link ElementHelper#dragAndDrop(WebElement, WebElement)}
+   */
+  @Deprecated
   public static void dragAndDrop(WebElement from, WebElement to) {
-    Actions act = new Actions(SeleniumDriver.getDriver());
-    //Dragged and dropped.
-    act.dragAndDrop(from, to).build().perform();
+    ElementHelper.dragAndDrop(from, to);
   }
 
   /**
    * Performs click-and-hold at the location of the element, moves by a given offset, then releases the mouse.
+   * @deprecated Use {@link ElementHelper#dragAndDropByOffset(WebElement, int, int)}
    */
+  @Deprecated
   public static void dragAndDropByOffset(WebElement element, int xOffset, int yOffset) {
-    Actions actions = new Actions(SeleniumDriver.getDriver());
-    actions.dragAndDropBy(element, xOffset, yOffset).build().perform();
+    ElementHelper.dragAndDropByOffset(element, xOffset, yOffset);
   }
 
+  /**
+   * @deprecated Use {@link ElementHelper#clickOnElement(WebElement)}
+   */
+  @Deprecated
   public static void clickObject(WebElement element) {
-    element.click();
+    ElementHelper.clickOnElement(element);
   }
 
+  /**
+   * @deprecated Use {@link ElementHelper#sendKeys(WebElement, String)}
+   */
+  @Deprecated
   public static void sendKeys(WebElement element, String keys) {
-    element.sendKeys(keys);
+    ElementHelper.sendKeys(element, keys);
   }
 
+  /**
+   * @deprecated Use {@link WaitHelper#waitForElementToBeDisplayed(WebElement, long)}
+   */
+  @Deprecated
   public static void waitElementIsVisible(WebElement element, long timeoutInSec) {
-    WebDriverWait wait = new WebDriverWait(SeleniumDriver.getDriver(), timeoutInSec);
-    wait.until(ExpectedConditions.visibilityOf(element));
+    WaitHelper.waitForElementToBeDisplayed(element, timeoutInSec);
   }
 
+  /**
+   * @deprecated Use {@link WaitHelper#waitForElementToBeDisplayed(WebElement)}
+   */
+  @Deprecated
   public static void waitElementIsVisible(WebElement element) {
-    waitElementIsVisible(element, DEFAULT_TIMEOUT);
+    WaitHelper.waitForElementToBeDisplayed(element);
   }
 
+  /**
+   * @deprecated Use {@link ElementHelper#clickOnElement(WebElement, long)}
+   */
+  @Deprecated
   public static void waitAndClick(WebElement element, long timeOutInSec) {
-    waitElementIsVisible(element, timeOutInSec);
-    element.click();
+    ElementHelper.clickOnElement(element, timeOutInSec);
   }
 
+  /**
+   * @deprecated Use {@link ElementHelper#clickOnElement(WebElement)}
+   */
+  @Deprecated
   public static void waitAndClick(WebElement element) {
-    waitAndClick(element, DEFAULT_TIMEOUT);
-  }
-
-  public static String readParameters(String property) throws IOException {
-    return connectProperties.getProperty(property);
+    ElementHelper.clickOnElement(element);
   }
 
   /**
    * Replacing the value of the text box when clear is not working
    * https://github.com/SeleniumHQ/selenium/issues/6741
+   *
+   * @deprecated Use {@link ElementHelper#replaceElementValue(WebElement, String)}
    */
+  @Deprecated
   public static void replaceElementValue(WebElement element, String value) {
-    replaceElementValue(element, value, 1024);
+    ElementHelper.replaceElementValue(element, value);
   }
 
+  /**
+   * @deprecated Use {@link ElementHelper#replaceElementValue(WebElement, String, int)}
+   */
+  @Deprecated
   public static void replaceElementValue(WebElement element, String value, int limit) {
-    boolean flag = false;
-    for (int i = 0; i < limit; i++) {
-      if (element.getAttribute("value").equals(StringUtils.EMPTY)) {
-        flag = true;
-        break;
-      }
-      element.sendKeys(Keys.BACK_SPACE);
-    }
-    if (!flag) {
-      Assert.fail("Element's current value is not cleared - " + element + " - "
-                    + "Current value :" + element.getAttribute("value"));
-    }
-    element.sendKeys(value);
+    ElementHelper.replaceElementValue(element, value, limit);
   }
 
+  /**
+   * @deprecated Use {@link ElementHelper#isElementDisplayed(WebElement)}
+   */
+  @Deprecated
   public static boolean verifyElementPresent(String locator) {
-    try {
-      SeleniumDriver.getDriver().findElement(By.xpath(locator));
-      return true;
-    } catch (Exception e) {
-      return false;
-    }
-  }
-
-  public static <T> T getPropertiesLocators(Class<T> className) {
-    return PageFactory.initElements(
-      SeleniumDriver.getDriver(), className);
+    WebElement element = SeleniumDriver.getDriver().findElement(By.xpath(locator));
+    return ElementHelper.isElementDisplayed(element);
   }
 }

--- a/src/main/java/io/cdap/e2e/utils/WaitHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/WaitHelper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.e2e.utils;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wait helper
+ */
+public class WaitHelper {
+  private static final Logger logger = LoggerFactory.getLogger(WaitHelper.class);
+
+  public static void waitForPageToLoad(long pageLoadTimeoutInSeconds) {
+    ExpectedCondition<Boolean> pageLoadCondition = new ExpectedCondition<Boolean>() {
+      @Override
+      public @Nullable Boolean apply(@Nullable WebDriver webDriver) {
+        return ((JavascriptExecutor) webDriver).executeScript("return document.readyState").equals("complete");
+      }
+    };
+
+    logger.info("Waiting for the page to load with timeout: " + pageLoadTimeoutInSeconds);
+    SeleniumDriver.getWaitDriver(pageLoadTimeoutInSeconds).until(pageLoadCondition);
+  }
+
+  public static void waitForPageToLoad() {
+    logger.info("Waiting for the page to load " +
+      "with the default page load timeout: " + ConstantsUtil.PAGE_LOAD_TIMEOUT_SECONDS);
+    waitForPageToLoad(ConstantsUtil.PAGE_LOAD_TIMEOUT_SECONDS);
+  }
+
+  public static WebElement waitForElementToBePresent(By locator) {
+    logger.info("Waiting for the element: " + locator + " to be present " +
+      "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
+    return SeleniumDriver.getWaitDriver().until(ExpectedConditions.presenceOfElementLocated(locator));
+  }
+
+  public static WebElement waitForElementToBeDisplayed(WebElement element) {
+    logger.info("Waiting for the element: " + element + " to be displayed " +
+      "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
+    return SeleniumDriver.getWaitDriver().until(ExpectedConditions.visibilityOf(element));
+  }
+
+  public static WebElement waitForElementToBeDisplayed(WebElement element, long timeoutInSeconds) {
+    logger.info("Waiting for the element: " + element + " to be displayed " +
+      "with the timeout: " + timeoutInSeconds + " seconds");
+    return SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.visibilityOf(element));
+  }
+
+  public static WebElement waitForElementToBeClickable(WebElement element) {
+    logger.info("Waiting for the element: " + element + " to be clickable " +
+      "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
+    return SeleniumDriver.getWaitDriver().until(ExpectedConditions.elementToBeClickable(element));
+  }
+
+  public static WebElement waitForElementToBeClickable(WebElement element, long timeoutInSeconds) {
+    logger.info("Waiting for the element: " + element + " to be clickable " +
+      "with the timeout: " + timeoutInSeconds + " seconds");
+    return SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.elementToBeClickable(element));
+  }
+
+  public static boolean waitForElementToBeHidden(WebElement element) {
+    logger.info("Waiting for the element: " + element + " to be hidden " +
+      "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
+    return SeleniumDriver.getWaitDriver().until(ExpectedConditions.invisibilityOf(element));
+  }
+
+  public static boolean waitForElementToBeHidden(WebElement element, long timeoutInSeconds) {
+    logger.info("Waiting for the element: " + element + " to be hidden " +
+      "with the timeout: " + timeoutInSeconds + " seconds");
+    return SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.invisibilityOf(element));
+  }
+}


### PR DESCRIPTION
Changes: 

1. SeleniumHelper class has been divided into four classes:
WaitHelper, 
ElementHelper, 
PageHelper, 
AssertionHelper

2. A few common steps added in the PipelineSteps along with their Actions and Locators

@itsankit-google @rmstar @tivv Kindly review.
cc: @sawantpritam @ksahilCF 