### PR TITLE
click on the element and move to avoid overlap

### DIFF
--- a/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
@@ -452,4 +452,14 @@ public class CdfStudioActions {
   public static void closeStatusBanner() {
     ElementHelper.clickOnElement(CdfStudioLocators.statusBannerCloseButton);
   }
+
+  /**
+   * Click on the element and move.
+   * @param pluginName plugin title.
+   * @param xOffset horizontal move offset.
+   * @param yOffset vertical move offset.
+   */
+  public static void movePlugin(String pluginName, int xOffset, int yOffset) {
+    ElementHelper.dragAndDropByOffset(CdfStudioLocators.locatePluginNodeInCanvas(pluginName), xOffset, yOffset);
+  }
 }

--- a/src/main/java/stepsdesign/PipelineSteps.java
+++ b/src/main/java/stepsdesign/PipelineSteps.java
@@ -595,4 +595,8 @@ public class PipelineSteps implements CdfHelper {
     CdfPluginPropertiesActions.verifyRadioButtonPluginPropertySelectedValue(pluginProperty, value);
   }
 
+  @Then("Move plugins: {string} by xOffset {int} and yOffset {int}")
+  public void movePlugin(String pluginName, int xOffset, int yOffset) {
+    CdfStudioActions.movePlugin(pluginName, xOffset, yOffset);
+  }
 }


### PR DESCRIPTION
Right now, selecting the same plugin will cause overlap issue.
e.g:
![image](https://user-images.githubusercontent.com/25891353/174908527-2e4c86c4-8224-4a8d-99b5-b0df90626433.png)
Then it's impossible to enter the `File` plugin properties.

Adding `moveElement` logic will help to resolve the issue.