### PR TITLE
CDAP-19392 & CDAP-19390

### DIFF
--- a/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
@@ -25,6 +25,7 @@ import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.SeleniumHelper;
 import io.cdap.e2e.utils.WaitHelper;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +112,24 @@ public class CdfStudioActions {
    * @param pluginName
    */
   public static void navigateToPluginPropertiesPage(String pluginName) {
-    ElementHelper.hoverOverElement(CdfStudioLocators.locatePluginNodeInCanvas(pluginName));
+    int attempts = 1;
+    while (attempts <= ConstantsUtil.MAX_RETRY_ATTEMPTS) {
+      try {
+        ElementHelper.hoverOverElement(CdfStudioLocators.locatePluginNodeInCanvas(pluginName));
+        WaitHelper.waitForElementToBeDisplayed(CdfStudioLocators.locatePluginPropertiesButton(pluginName),
+                                               ConstantsUtil.SMALL_TIMEOUT_SECONDS);
+        break;
+      } catch (TimeoutException e) {
+        /* Properties button is displayed on hover of the plugin node.
+        When Pipeline is created from wrangler connection, Plugin node is displayed in left corner first
+        and then aligned in the middle on canvas. In case if Hover action happens before plugin get aligned,
+        properties button gets hidden and timeout exception is thrown.*/
+        if (attempts == ConstantsUtil.MAX_RETRY_ATTEMPTS) {
+          throw e;
+        }
+      }
+      attempts++;
+    }
     ElementHelper.clickOnElement(CdfStudioLocators.locatePluginPropertiesButton(pluginName));
   }
 
@@ -256,7 +274,7 @@ public class CdfStudioActions {
    * Click on logs button in preview menu
    */
   public static void clickPreviewLogsButton() {
-    CdfStudioLocators.previewLogsButton.click();
+    ElementHelper.clickOnElement(CdfStudioLocators.previewLogsButton);
   }
 
   /**

--- a/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
+++ b/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
@@ -55,6 +55,7 @@ public class ConstantsUtil {
   public static final String PREVIEW_TAB = "Preview";
   public static final String DOCUMENTATION_TAB = "Documentation";
   public static final String SCREENSHOT_FOR_ALL_STEPS = "screenshotForAllSteps";
+  public static final int MAX_RETRY_ATTEMPTS = 5;
   public static final String LOGS_SEPARATOR_MESSAGE = "---------------------------------------------------------" +
     "------------------------------MESSAGE----------------------------------------------------------------------" +
     "-----------------";


### PR DESCRIPTION
CDAP-19392 - It is Failing while waiting for visibility of plugin properties button and not for plugin node.
Properties button is displayed on hover of the plugin node.
When Pipeline is created from wrangler connection, Plugin node is displayed in left corner first and then aligned in the middle on canvas. Hover action happens before plugin get aligned, so properties button gets hidden in meantime.

@itsankit-google @rmstar Please review.