### PR TITLE
preview log intermittent failure fix

### DIFF
--- a/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
@@ -476,6 +476,7 @@ public class CdfStudioActions {
     while (attempts <= ConstantsUtil.MAX_RETRY_ATTEMPTS) {
       try {
         ElementHelper.clickIfDisplayed(CdfStudioLocators.statusBannerCloseButtonLocator);
+        WaitHelper.waitForElementToBeHidden(CdfStudioLocators.statusBanner);
         break;
       } catch (ElementClickInterceptedException e) {
         /* If attempt to click on close status banner happens before its loaded and stable


### PR DESCRIPTION
@itsankit-google @rmstar Please review.

In recent builds few tests intermittently fail while clicking on preview logs button with click intercepted exception as click happens before status banner gets hidden completely.
Added wait till banner gets hidden.