### PR TITLE
open sink only if needed

### DIFF
--- a/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
@@ -309,7 +309,10 @@ public class CdfStudioActions {
    * Click on the Plugin group title: Sink
    */
   public static void clickSink() {
-    ElementHelper.clickOnElement(CdfStudioLocators.sink);
+    // Check if Sink is not already expanded
+    if (!ElementHelper.isElementDisplayed(CdfStudioLocators.bigQueryObject)) {
+      ElementHelper.clickOnElement(CdfStudioLocators.sink);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR makes a small change in the openSink method. I noticed that if the test is selecting multiple sinks at a time, every other click results in shrinking the sink group.