### PR TITLE
[CDAP-19833] Upgrade github actions to v3 for node16 support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
             CDAP_GPG_PRIVATE_KEY:cdapio-github-builds/CDAP_GPG_PRIVATE_KEY
 
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: e2e
           ref: ${{ inputs.ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,17 +31,17 @@ jobs:
     steps:
       # Pinned 1.0.0 version
       - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           repository: data-integrations/google-cloud
           path: plugin
       - name: Checkout e2e test repo
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           path: e2e
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
@@ -54,13 +54,13 @@ jobs:
         if: ${{ github.event.workflow_run.event == 'workflow_dispatch' || github.event.workflow_run.event == 'push' }}
         run: python3 e2e/src/main/scripts/run_e2e_test.py --framework yes
       - name: Upload report
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: Cucumber report
           path: ./plugin/target/cucumber-reports
       - name: Upload debug files
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: Debug files


### PR DESCRIPTION
Recently we started seeing this warning in github action builds that `Node.js 12 actions are deprecated`.

```
Warning: Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/cache, actions/cache

```
This PR helps in upgrading the `actions/cache, actions/checkout, actions/upload-artifact` to `v3` which has node16 support.