### PR TITLE
set default download path to target for chrome driver

### DIFF
--- a/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
+++ b/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
@@ -28,8 +28,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 
 /**
  * Represents SeleniumDriver
@@ -52,6 +54,12 @@ public class SeleniumDriver {
     chromeOptions.addArguments("--disable-gpu");
     chromeOptions.addArguments("--disable-dev-shm-usage");
     chromeOptions.addArguments("--disable-features=VizDisplayCompositor");
+    // set default download directory
+    String downloadDir = Paths.get("target").toAbsolutePath().toString() + "/downloads";
+    HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+    chromePrefs.put("profile.default_content_settings.popups", 0);
+    chromePrefs.put("download.default_directory", downloadDir);
+    chromeOptions.setExperimentalOption("prefs", chromePrefs);
     chromeDriver = new ChromeDriver(chromeOptions);
     chromeDriver.manage().window().maximize();
     HttpCommandExecutor executor = (HttpCommandExecutor) chromeDriver.getCommandExecutor();


### PR DESCRIPTION
This PR sets the default download path for chrome driver to `target/downloads` directory. It helps with the tests where a file (e.g., exported pipeline json) needs to be downloaded and re-read from the disk.