### PR TITLE
Added stderr pipe for subprocess

### DIFF
--- a/src/main/scripts/run_e2e_test_module.py
+++ b/src/main/scripts/run_e2e_test_module.py
@@ -23,7 +23,9 @@ import zipfile
 import shutil
 
 def run_shell_command(cmd):
-    process = subprocess.run(cmd.split(" "))
+    process = subprocess.run(cmd.split(" "), stderr=subprocess.PIPE)
+    if process.returncode != 0:
+        print("Process completed with error: ", process.stderr)
     assert process.returncode == 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding a stderr pipe for subprocess in script `run_e2e_test_module.py`

Let the developer know error when the subprocess complete with a non 0 return code.

This also makes the script standard with scripts `run_e2e_test.py`