### PR TITLE
Update the driver module name

### DIFF
--- a/src/main/scripts/driver_details.yaml
+++ b/src/main/scripts/driver_details.yaml
@@ -19,12 +19,12 @@ modules:
     driver_prop: '[{"name":"oracle","type":"jdbc","className":"oracle.jdbc.driver.OracleDriver","description":"Plugin for the Oracle 12c JDBC driver"}]'
     artifact_name: 'ojdbc8'
     artifact_version: '12.2.0.1'
-  cloudsql-mysql:
+  cloudsql-mysql-plugin:
     url: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/releases/download/v1.0.16/mysql-socket-factory-connector-j-8-1.0.16-jar-with-driver-and-dependencies.jar
     driver_prop: '[{"name":"cloudsql-mysql","type":"jdbc","className":"com.mysql.jdbc.Driver","description":"Plugin for the CloudSQL MySQL JDBC driver"}]'
     artifact_name: 'cloudsql-mysql-plugin'
     artifact_version: '8-1.0.16-jar-with-driver-and-dependencies'
-  cloudsql-postgresql:
+  cloudsql-postgresql-plugin:
     url: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/releases/download/v1.0.16/postgres-socket-factory-1.0.16-jar-with-driver-and-dependencies.jar
     driver_prop: '[{"name":"cloudsql-postgresql","type":"jdbc","className":"org.postgresql.Driver","description":"Plugin for the CloudSQL PostgreSQL JDBC driver"}]'
     artifact_name: 'cloudsql-postgresql-plugin'


### PR DESCRIPTION
Due to a mismatch between the module name in driver_details.yaml file and the e2e.yml file on Github Actions, the JDBC Driver Locator was unable to locate the module appropriately.