### PR TITLE
Use Selenium manager instead of Web driver manager  to download latest chrome driver 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@ the License.-->
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
-      <version>4.1.3</version>
+      <version>4.11.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
+++ b/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
@@ -16,9 +16,9 @@
 
 package io.cdap.e2e.utils;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.SessionId;
@@ -45,7 +45,7 @@ public class SeleniumDriver {
   private static ChromeDriver chromeDriver;
 
   SeleniumDriver() throws IOException {
-    WebDriverManager.chromedriver().setup();
+    ChromeDriverService service = new ChromeDriverService.Builder().build();
     ChromeOptions chromeOptions = new ChromeOptions();
     chromeOptions.addArguments("--no-sandbox");
     chromeOptions.addArguments("--disable-setuid-sandbox");
@@ -61,7 +61,7 @@ public class SeleniumDriver {
     chromePrefs.put("profile.default_content_settings.popups", 0);
     chromePrefs.put("download.default_directory", downloadDir);
     chromeOptions.setExperimentalOption("prefs", chromePrefs);
-    chromeDriver = new ChromeDriver(chromeOptions);
+    chromeDriver = new ChromeDriver(service, chromeOptions);
     chromeDriver.manage().window().maximize();
     HttpCommandExecutor executor = (HttpCommandExecutor) chromeDriver.getCommandExecutor();
     url = executor.getAddressOfRemoteServer();


### PR DESCRIPTION
Updating the process of downloading chrome driver after new release of chrome v116 which has chrome + chromedriver integrated. Release Doc - (https://chromedriver.chromium.org/downloads/version-selection)