### PR TITLE
Adding scripts to deploy required plugins on sandbox from CDAP hub.

### DIFF
--- a/src/main/scripts/required_plugins.yaml
+++ b/src/main/scripts/required_plugins.yaml
@@ -1,0 +1,7 @@
+# Note - Before adding the artifact name check the list of available packages in the Hub using:
+# https://hub.cdap.io/v2/packages.json
+
+plugins:
+  multidatabase-table-plugins:
+    artifact_name: 'plugin-multi-table-plugins'
+    artifact_version: '1.4.0'

--- a/src/main/scripts/run_e2e_test.py
+++ b/src/main/scripts/run_e2e_test.py
@@ -65,6 +65,15 @@ assert process.returncode == 0
 res = requests.put('http://localhost:11015/v3/preferences', headers= {'Content-Type': 'application/json'}, json={'task.executor.system.resources.memory': 4096})
 assert res.ok or print(res.text)
 
+# Upload required plugins from CDAP HUb
+plugin_details_file = open(os.path.join('e2e', 'src', 'main', 'scripts', 'required_plugins.yaml'))
+plugin_details = yaml.load(plugin_details_file, Loader=yaml.FullLoader)
+
+for plugin, details in plugin_details['plugins'].items():
+    artifact_name = details.get('artifact_name')
+    artifact_version = details.get('artifact_version')
+    subprocess.run(["python", "upload_required_plugins.py", artifact_name, artifact_version])
+
 module_to_build = ""
 if args.module:
     module_to_build = args.module

--- a/src/main/scripts/upload_required_plugins.py
+++ b/src/main/scripts/upload_required_plugins.py
@@ -30,10 +30,13 @@ actions = response_data["actions"][0]
 plugin_details = actions["arguments"]
 
 # Get the required details from specs.
-plugin_name = plugin_details[0]["value"]
-plugin_version = plugin_details[1]["value"]
-plugin_config = plugin_details[3]["value"]
-plugin_jar = plugin_details[4]["value"]
+plugin_details_dictionary = {
+    item['name']: item['value'] for item in plugin_details
+}
+plugin_name = plugin_details_dictionary['name']
+plugin_version = plugin_details_dictionary['version']
+plugin_config = plugin_details_dictionary['config']
+plugin_jar = plugin_details_dictionary['jar']
 
 # Get the Jar content of the Plugin from the Hub and upload the content to CDAP namespace.
 jar_file = requests.get(f"https://hub.cdap.io/v2/packages/{package_name}/{plugin_version}/{plugin_jar}")

--- a/src/main/scripts/upload_required_plugins.py
+++ b/src/main/scripts/upload_required_plugins.py
@@ -1,0 +1,68 @@
+# Copyright © 2023 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import json
+import requests
+import jq
+import sys
+
+# Get the Package name and Package version.
+package_name = sys.argv[1]
+package_version = sys.argv[2]
+
+
+# Get the specs of the Plugin from response.
+res = requests.get(f"https://hub.cdap.io/v2/packages/{package_name}/{package_version}/spec.json")
+assert res.ok or print(f"Specs not found for the Plugin. Status code: {res.status_code}")
+response_data = res.json()
+actions = response_data["actions"][0]
+plugin_details = actions["arguments"]
+
+# Get the required details from specs.
+plugin_name = plugin_details[0]["value"]
+plugin_version = plugin_details[1]["value"]
+plugin_config = plugin_details[3]["value"]
+plugin_jar = plugin_details[4]["value"]
+
+# Get the Jar content of the Plugin from the Hub and upload the content to CDAP namespace.
+jar_file = requests.get(f"https://hub.cdap.io/v2/packages/{package_name}/{plugin_version}/{plugin_jar}")
+
+res = requests.post(
+    f"http://localhost:11015/v3/namespaces/default/artifacts/{plugin_name}",
+    headers = {
+        "Content-Type": "application/octet-stream",
+        "Artifact-Version": plugin_version,
+        },
+    data = jar_file.content,
+)
+assert res.ok or print(res.text)
+
+# Get the Json content of Plugin from the Hub and upload the content.
+json_file = requests.get(f"https://hub.cdap.io/v2/packages/{package_name}/{plugin_version}/{plugin_config}")
+
+# Getting the properties of the plugin from json response.
+data = json_file.json()
+filter_expression = jq.compile('.properties')
+filtered_data = filter_expression.input(data).all()
+data_to_upload = json.dumps(filtered_data[0])
+
+# Uploading the Json content.
+res = requests.put(
+    f"http://localhost:11015/v3/namespaces/default/artifacts/{plugin_name}/versions/{plugin_version}/properties",
+    headers = {
+        "Content-Type": "application/json",
+        },
+    data = data_to_upload,
+)
+assert res.ok or print(res.text)


### PR DESCRIPTION
Added a script to deploy required plugins from Hub which are not present by default in CDAP studio. Using the Hub API for the Plugin deployment. [(Hub API)](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/554401840/Hub+API)

Flow :-

1. Add the plugin name and version in ``` required_plugins.yaml``` which you want to deploy on the sandbox.
2. Once the sandbox is created we read the plugin name and plugin version added in ``` required_plugins.yaml``` and the ``` upload_required_plugins.py ``` script is called which will upload each plugin one by one on default namespace.