### PR TITLE
Fix BQMT Plugin upload error

### DIFF
--- a/src/main/scripts/run_e2e_test.py
+++ b/src/main/scripts/run_e2e_test.py
@@ -74,7 +74,7 @@ plugin_details = yaml.load(plugin_details_file, Loader=yaml.FullLoader)
 for plugin, details in plugin_details['plugins'].items():
     artifact_name = details.get('artifact_name')
     artifact_version = details.get('artifact_version')
-    subprocess.run(["python", "upload_required_plugins.py", artifact_name, artifact_version])
+    subprocess.run(["python3.8", os.path.join('e2e', 'src', 'main', 'scripts', 'upload_required_plugins.py'), artifact_name, artifact_version])
 
 module_to_build = ""
 if args.module:

--- a/src/main/scripts/upload_required_plugins.py
+++ b/src/main/scripts/upload_required_plugins.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2023 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -60,7 +61,7 @@ filter_expression = jq.compile('.properties')
 filtered_data = filter_expression.input(data).all()
 data_to_upload = json.dumps(filtered_data[0])
 
-# Uploading the Json content.
+# Uploading the Json content
 res = requests.put(
     f"http://localhost:11015/v3/namespaces/default/artifacts/{plugin_name}/versions/{plugin_version}/properties",
     headers = {


### PR DESCRIPTION
Error - Error in opening the file which uploads the BQMT plugin due to incorrect path.

Fix - Providing exact path to the file to resolve the error. 