### PR TITLE
Refresh page till pipeline runs

### DIFF
--- a/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
@@ -127,7 +127,7 @@ public class CdfPipelineRunAction {
    * Timeout: {@link ConstantsUtil#IMPLICIT_TIMEOUT_SECONDS}
    */
   public static void waitTillPipelineRunCompletes() throws InterruptedException {
-    try{
+    try {
       // Wait for the Pipeline run to complete for the default timeout
       WaitHelper.waitForElementToBeHidden(CdfPipelineRunLocators.runningStatus);
     } catch (Exception e) {

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
@@ -127,15 +127,24 @@ public class CdfPipelineRunAction {
    * Timeout: {@link ConstantsUtil#IMPLICIT_TIMEOUT_SECONDS}
    */
   public static void waitTillPipelineRunCompletes() throws InterruptedException {
-    // Adding a page refresh in case tests are running on CDF to update the pipeline status.
-      RetryUtils.retry(ConstantsUtil.PIPELINE_REFRESH_TIMEOUT_SECONDS, ConstantsUtil.PIPELINE_RUN_TIMEOUT_SECONDS,
-        10, () -> {
-        PageHelper.refreshCurrentPage();
-        return !(isRunning());
-        }
-      );
+    // Wait for the Pipeline run to complete for the default timeout
+    WaitHelper.waitForElementToBeHidden(CdfPipelineRunLocators.runningStatus);
 
-    waitTillPipelineRunCompletes(ConstantsUtil.IMPLICIT_TIMEOUT_SECONDS);
+    // Loop to refresh the page if the pipeline is still running till max refresh count
+    int maxRefreshCount = ConstantsUtil.MAX_PAGE_REFRESH_ATTEMPTS;
+    while (maxRefreshCount > 0) {
+      boolean isPipelineRunning = isRunning();
+
+      if (isPipelineRunning) {
+        PageHelper.refreshCurrentPage();
+        WaitHelper.waitForElementToBeHidden(
+                CdfPipelineRunLocators.runningStatus, ConstantsUtil.IMPLICIT_TIMEOUT_SECONDS);
+      } else {
+        break;
+      }
+
+      --maxRefreshCount;
+    }
   }
 
   /**

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfPipelineRunAction.java
@@ -127,8 +127,13 @@ public class CdfPipelineRunAction {
    * Timeout: {@link ConstantsUtil#IMPLICIT_TIMEOUT_SECONDS}
    */
   public static void waitTillPipelineRunCompletes() throws InterruptedException {
-    // Wait for the Pipeline run to complete for the default timeout
-    WaitHelper.waitForElementToBeHidden(CdfPipelineRunLocators.runningStatus);
+    try{
+      // Wait for the Pipeline run to complete for the default timeout
+      WaitHelper.waitForElementToBeHidden(CdfPipelineRunLocators.runningStatus);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
 
     // Loop to refresh the page if the pipeline is still running till max refresh count
     int maxRefreshCount = ConstantsUtil.MAX_PAGE_REFRESH_ATTEMPTS;
@@ -137,6 +142,15 @@ public class CdfPipelineRunAction {
 
       if (isPipelineRunning) {
         PageHelper.refreshCurrentPage();
+
+        try {
+          Thread.sleep(5000); // Wait for 5 second after the refresh
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+
+        WaitHelper.waitForPageToLoad();
+        WaitHelper.waitForElementToBeClickable(CdfPipelineRunLocators.runDropdownButton);
         WaitHelper.waitForElementToBeHidden(
                 CdfPipelineRunLocators.runningStatus, ConstantsUtil.IMPLICIT_TIMEOUT_SECONDS);
       } else {

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfSignInActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfSignInActions.java
@@ -22,7 +22,7 @@ import io.cdap.e2e.utils.SeleniumHelper;
 import io.cdap.e2e.utils.WaitHelper;
 
 import java.io.IOException;
-
+import java.time.Duration;
 
 
 /**
@@ -41,13 +41,17 @@ public class CdfSignInActions {
         ElementHelper.clickOnElement(cdfSignInLocator.nextButton);
 
         ElementHelper.clickIfDisplayed(cdfSignInLocator.selectTestAccount(ConstantsUtil.CDF_TEST_ACCOUNT_NAME),
-          ConstantsUtil.SMALL_TIMEOUT_SECONDS, cdfSignInLocator.clickOnContinueButton());
+          ConstantsUtil.CDF_LOGIN_TIMEOUT_SECONDS, cdfSignInLocator.clickOnContinueButton());
 
-        ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnContinueButton(), ConstantsUtil.SMALL_TIMEOUT_SECONDS,
-          cdfSignInLocator.locatePluginNameInList(ConstantsUtil.FIRST_PLUGIN_IN_LIST, "Source"));
+        ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnContinueButton());
+        ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnAllowButton());
+        Thread.sleep(20000);
 
-        ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnAllowButton(), ConstantsUtil.SMALL_TIMEOUT_SECONDS,
-          cdfSignInLocator.locatePluginNameInList(ConstantsUtil.FIRST_PLUGIN_IN_LIST, "Source"));
+//        ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnContinueButton(), ConstantsUtil.SMALL_TIMEOUT_SECONDS,
+//          cdfSignInLocator.locatePluginNameInList(ConstantsUtil.FIRST_PLUGIN_IN_LIST, "Source"));
+//
+//        ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnAllowButton(), ConstantsUtil.SMALL_TIMEOUT_SECONDS,
+//          cdfSignInLocator.locatePluginNameInList(ConstantsUtil.FIRST_PLUGIN_IN_LIST, "Source"));
 
     }
 

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfSignInActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfSignInActions.java
@@ -45,7 +45,6 @@ public class CdfSignInActions {
 
         ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnContinueButton());
         ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnAllowButton());
-        Thread.sleep(20000);
 
 //        ElementHelper.clickIfDisplayed(cdfSignInLocator.clickOnContinueButton(), ConstantsUtil.SMALL_TIMEOUT_SECONDS,
 //          cdfSignInLocator.locatePluginNameInList(ConstantsUtil.FIRST_PLUGIN_IN_LIST, "Source"));

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
@@ -221,7 +221,6 @@ public class CdfStudioActions {
    * @param value              actual value to enter
    */
   public static void enterRuntimeArgumentValue(String runtimeArgumentKey, String value) throws InterruptedException {
-    Thread.sleep(3000);
     ElementHelper.sendKeys(CdfStudioLocators.runtimeArgsValue(runtimeArgumentKey), value);
   }
 

--- a/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
+++ b/src/main/java/io/cdap/e2e/pages/actions/CdfStudioActions.java
@@ -25,6 +25,7 @@ import io.cdap.e2e.utils.FileImportUtil;
 import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.SeleniumHelper;
 import io.cdap.e2e.utils.WaitHelper;
+import io.cucumber.java8.Th;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.TimeoutException;
@@ -33,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URISyntaxException;
+import java.time.Duration;
 
 /**
  * Represents Cdf Studio Page Actions
@@ -178,8 +180,9 @@ public class CdfStudioActions {
     pipelineName();
     pipelineNameIp(pipelineName);
     pipelineSave();
-    WaitHelper.waitForElementToBeDisplayed(CdfStudioLocators.statusBanner);
-    WaitHelper.waitForElementToBeHidden(CdfStudioLocators.statusBanner);
+    WaitHelper.waitForElementToBeOptionallyDisplayed(CdfStudioLocators.statusBannerDisplay(),
+                                                     ConstantsUtil.SMALL_TIMEOUT_SECONDS);
+    WaitHelper.waitForElementToBeHidden(CdfStudioLocators.statusBannerDisplay(), ConstantsUtil.SMALL_TIMEOUT_SECONDS);
   }
 
   /**
@@ -217,7 +220,8 @@ public class CdfStudioActions {
    * @param runtimeArgumentKey macro argument
    * @param value              actual value to enter
    */
-  public static void enterRuntimeArgumentValue(String runtimeArgumentKey, String value) {
+  public static void enterRuntimeArgumentValue(String runtimeArgumentKey, String value) throws InterruptedException {
+    Thread.sleep(3000);
     ElementHelper.sendKeys(CdfStudioLocators.runtimeArgsValue(runtimeArgumentKey), value);
   }
 
@@ -286,8 +290,9 @@ public class CdfStudioActions {
    *
    * @param status
    */
-  public static void verifyPipelinePreviewStatusInLogs(String status) {
-    AssertionHelper.verifyElementDisplayed(CdfLogLocators.getPipelineStatusFromLogs(status));
+  public static void verifyPipelinePreviewStatusInLogs(String status) throws InterruptedException {
+    WaitHelper.waitForElementToBeDisplayed(CdfLogLocators.getPipelineStatusFromLogs(status));
+  //  AssertionHelper.verifyElementDisplayed(CdfLogLocators.getPipelineStatusFromLogs(status));
   }
 
   /**
@@ -295,7 +300,8 @@ public class CdfStudioActions {
    */
   public static void pipelineDeploy() {
     ElementHelper.clickOnElement(CdfStudioLocators.pipelineDeploy);
-    WaitHelper.waitForElementToBeDisplayed(CdfStudioLocators.deployingPipelineMessage);
+    WaitHelper.waitForElementToBeOptionallyDisplayed(CdfStudioLocators.locatorOfdeployingPipelineMessage(),
+                                                     ConstantsUtil.SMALL_TIMEOUT_SECONDS);
     WaitHelper.waitForElementToBeHidden(
       CdfStudioLocators.locatorOfdeployingPipelineMessage(), ConstantsUtil.PIPELINE_DEPLOY_TIMEOUT_SECONDS);
   }
@@ -529,10 +535,14 @@ public class CdfStudioActions {
    * Imports a pipeline from the specified file path.
    * @param filePath The path to the file containing the pipeline to be imported.
    **/
-  public static void importPipeline(String filePath) throws URISyntaxException {
+  public static void importPipeline(String filePath) throws URISyntaxException, InterruptedException {
     WaitHelper.waitForElementToBeDisplayed(CdfStudioLocators.importPipelineButton);
     FileImportUtil.uploadFile(CdfStudioLocators.importPipelineInputTag(), filePath);
-    clickOnFixAllButtonIfDisplayed();
+
+//    clickOnFixAllButtonIfDisplayed();
+    ElementHelper.clickOnElement(CdfStudioLocators.fixAllButtonWrangler);
+    Thread.sleep(20000);
+    WaitHelper.waitForPageToLoad();
   }
 
   /**

--- a/src/main/java/io/cdap/e2e/pages/locators/CdfSignInLocator.java
+++ b/src/main/java/io/cdap/e2e/pages/locators/CdfSignInLocator.java
@@ -51,7 +51,7 @@ public class CdfSignInLocator {
     }
 
     public static By locatePluginNameInList(String pluginName, String  pluginGroupName) {
-        return By.xpath("//div[@data-cy='plugin-" + pluginGroupName + "-group']" +
+        return By.xpath("//div[@data-testid='plugin-" + pluginGroupName + "-group']" +
                 "//div[contains(@class, 'PluginNameContainer')][normalize-space(text()) = '" + pluginName + "' " +
                 "or translate(normalize-space(text()),' ','') = '" + pluginName + "']");
     }

--- a/src/main/java/io/cdap/e2e/pages/locators/CdfStudioLocators.java
+++ b/src/main/java/io/cdap/e2e/pages/locators/CdfStudioLocators.java
@@ -171,12 +171,12 @@ public class CdfStudioLocators {
   }
 
   public static WebElement locatePluginGroupExpanded(String pluginGroupName) {
-    String xpath = "//div[@data-cy='plugin-" + pluginGroupName + "-group-summary' and @aria-expanded='true']";
+    String xpath = "//div[@data-testid='plugin-" + pluginGroupName + "-group-summary' and @aria-expanded='true']";
     return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
   }
 
   public static By locatorOfPluginGroupCollapsed(String pluginGroupName) {
-    String xpath = "//div[@data-cy='plugin-" + pluginGroupName + "-group-summary' and @aria-expanded='false']";
+    String xpath = "//div[@data-testid='plugin-" + pluginGroupName + "-group-summary' and @aria-expanded='false']";
     return By.xpath(xpath);
   }
 
@@ -185,19 +185,19 @@ public class CdfStudioLocators {
   }
 
   public static WebElement locatePluginNameInList(String pluginName, String  pluginGroupName) {
-    String xpath = "//div[@data-cy='plugin-" + pluginGroupName + "-group']" +
+    String xpath = "//div[@data-testid='plugin-" + pluginGroupName + "-group']" +
       "//div[contains(@class, 'PluginNameContainer')][normalize-space(text()) = '" + pluginName + "' " +
       "or translate(normalize-space(text()),' ','') = '" + pluginName + "']";
     return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
   }
 
   public static WebElement locateSinkPluginNameInList(String pluginName) {
-    String xpath = "//*[@data-cy='plugin-" + pluginName + "-batchsink']";
+    String xpath = "//*[@data-testid='plugin-" + pluginName + "-batchsink']";
     return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
   }
 
   public static WebElement locateRealtimeSourcePluginNameInList(String pluginName) {
-    String xpath = "//*[@data-cy='plugin-" + pluginName + "-streamingsource']";
+    String xpath = "//*[@data-testid='plugin-" + pluginName + "-streamingsource']";
     return SeleniumDriver.getDriver().findElement(By.xpath(xpath));
   }
 
@@ -272,8 +272,15 @@ public class CdfStudioLocators {
   @FindBy(how = How.XPATH, using = "//*[@id='import-pipeline']")
   public static WebElement importPipelineButton;
 
+  @FindBy(how = How.XPATH, using = "//button[@data-testid='fix-all-btn']")
+  public static WebElement fixAllButtonWrangler;
+
   public static By fixAllButton()  {
-    return By.xpath("//button[@data-cy='fix-all-btn']");
+    return By.xpath("//button[@data-testid='fix-all-btn']");
+  }
+
+  public static By statusBannerDisplay() {
+    return By.xpath("//*[@data-cy='valium-banner-hydrator']");
   }
 
   public static WebElement importPipelineInputTag() {

--- a/src/main/java/io/cdap/e2e/utils/CdfHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/CdfHelper.java
@@ -30,10 +30,12 @@ import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import stepsdesign.BeforeActions;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
+++ b/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
@@ -111,4 +111,6 @@ public class ConstantsUtil {
   public static final int PIPELINE_RUN_TIMEOUT_SECONDS = 900;
 
   public static final int PIPELINE_REFRESH_TIMEOUT_SECONDS = 120;
+
+  public static final int MAX_PAGE_REFRESH_ATTEMPTS = 10;
 }

--- a/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
+++ b/src/main/java/io/cdap/e2e/utils/ConstantsUtil.java
@@ -83,15 +83,20 @@ public class ConstantsUtil {
   /**
    * DEFAULT_TIMEOUT_SECONDS: To be used in external wait helpers defined in {@link WaitHelper}
    */
-  public static final int DEFAULT_TIMEOUT_SECONDS = 180;
+  public static final int DEFAULT_TIMEOUT_SECONDS = 300;
   /**
    * PAGE_LOAD_TIMEOUT_SECONDS: To be used as Selenium driver's default page load timeout
    */
-  public static final int PAGE_LOAD_TIMEOUT_SECONDS = 50;
+  public static final int PAGE_LOAD_TIMEOUT_SECONDS = 300;
   /**
    * SMALL_TIMEOUT_SECONDS: To be used as a small static wait (only if needed)
    */
-  public static final int SMALL_TIMEOUT_SECONDS = 5;
+  public static final int SMALL_TIMEOUT_SECONDS = 20;
+  /**
+   * CDFLOGIN_TIMEOUT_SECONDS: To be used as a small static wait (only if needed) for cdf login page
+   */
+  public static final int CDF_LOGIN_TIMEOUT_SECONDS = 50;
+
   /**
    * MEDIUM_TIMEOUT_SECONDS: To be used as a medium static wait (only if needed)
    */

--- a/src/main/java/io/cdap/e2e/utils/WaitHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/WaitHelper.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -28,243 +29,246 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Wait helper
  */
 public class WaitHelper {
-  private static final Logger logger = LoggerFactory.getLogger(WaitHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(WaitHelper.class);
 
-  /**
-   * Wait for page to load
-   *
-   * @param pageLoadTimeoutInSeconds timeout
-   */
-  public static void waitForPageToLoad(long pageLoadTimeoutInSeconds) {
-    ExpectedCondition<Boolean> pageLoadCondition = new ExpectedCondition<Boolean>() {
-      @Override
-      public @Nullable Boolean apply(@Nullable WebDriver webDriver) {
-        return ((JavascriptExecutor) webDriver).executeScript("return document.readyState").equals("complete");
-      }
-    };
+    /**
+     * Wait for page to load
+     *
+     * @param pageLoadTimeoutInSeconds timeout
+     */
+    public static void waitForPageToLoad(long pageLoadTimeoutInSeconds) {
+        ExpectedCondition<Boolean> pageLoadCondition = new ExpectedCondition<Boolean>() {
+            @Override
+            public @Nullable Boolean apply(@Nullable WebDriver webDriver) {
+                return ((JavascriptExecutor) webDriver).executeScript("return document.readyState").equals("complete");
+            }
+        };
 
-    logger.info("Waiting for the page to load with timeout: " + pageLoadTimeoutInSeconds);
-    SeleniumDriver.getWaitDriver(pageLoadTimeoutInSeconds).until(pageLoadCondition);
-  }
-
-  /**
-   * Wait for page to load
-   */
-  public static void waitForPageToLoad() {
-    logger.info("Waiting for the page to load " +
-      "with the default page load timeout: " + ConstantsUtil.PAGE_LOAD_TIMEOUT_SECONDS);
-    waitForPageToLoad(ConstantsUtil.PAGE_LOAD_TIMEOUT_SECONDS);
-  }
-
-  /**
-   * Wait for element to be present
-   *
-   * @param locator locator of the element
-   * @return WebElement
-   */
-  public static WebElement waitForElementToBePresent(By locator) {
-    logger.info("Waiting for the element: " + locator + " to be present " +
-      "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
-    return SeleniumDriver.getWaitDriver().until(ExpectedConditions.presenceOfElementLocated(locator));
-  }
-
-  /**
-   * Wait for element to be optionally present
-   *
-   * @param locator locator of the element
-   * @return WebElement
-   */
-  public static boolean waitForElementToBeOptionallyPresent(By locator, long timeoutInSeconds) {
-    logger.info("Waiting for the element: " + locator + " to be optionally present " +
-      "with the timeout: " + timeoutInSeconds + " seconds");
-    boolean flag = false;
-
-    try {
-      SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.presenceOfElementLocated(locator));
-      flag = true;
-      return flag;
-    } catch (Exception e) {
-      logger.info("Element: " + locator + " is not present");
-      return flag;
+        logger.info("Waiting for the page to load with timeout: " + pageLoadTimeoutInSeconds);
+        SeleniumDriver.getWaitDriver(pageLoadTimeoutInSeconds).until(pageLoadCondition);
     }
-  }
 
-  /**
-   * Wait for element to be displayed within the specified timeout
-   *
-   * @param element          WebElement to wait for
-   * @param timeoutInSeconds timeout
-   * @return WebElement
-   */
-  public static WebElement waitForElementToBeDisplayed(WebElement element, long timeoutInSeconds) {
-    logger.info("Waiting for the element: " + element + " to be displayed " +
-      "with the timeout: " + timeoutInSeconds + " seconds");
-    return SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.visibilityOf(element));
-  }
-
-  /**
-   * Wait for element to be displayed within the Default timeout: {@link ConstantsUtil#DEFAULT_TIMEOUT_SECONDS}
-   *
-   * @param element WebElement to wait for
-   * @return WebElement
-   */
-  public static WebElement waitForElementToBeDisplayed(WebElement element) {
-    return waitForElementToBeDisplayed(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
-  }
-
-  /**
-   * Wait for element to be displayed without failing, if the element does not get displayed
-   *
-   * @param locator          Locator of the WebElement
-   * @param timeoutInSeconds timeout
-   */
-  public static boolean waitForElementToBeOptionallyDisplayed(By locator, long timeoutInSeconds) {
-    logger.info("Waiting for the element: " + locator.toString() + " to be optionally displayed " +
-      "with the timeout: " + timeoutInSeconds + " seconds");
-
-    try {
-      SeleniumDriver.getWaitDriver(timeoutInSeconds)
-        .until(ExpectedConditions.visibilityOf(SeleniumDriver.getDriver().findElement(locator)));
-      return true;
-    } catch (NoSuchElementException e) {
-      logger.info("Element is not displayed");
-      return false;
-    } catch (StaleElementReferenceException e) {
-      logger.info("Element is not interactable");
-      return false;
+    /**
+     * Wait for page to load
+     */
+    public static void waitForPageToLoad() {
+        logger.info("Waiting for the page to load " +
+                "with the default page load timeout: " + ConstantsUtil.PAGE_LOAD_TIMEOUT_SECONDS);
+        waitForPageToLoad(ConstantsUtil.PAGE_LOAD_TIMEOUT_SECONDS);
     }
-  }
 
-  /**
-   * Wait for element to be clickable within the specified timeout
-   *
-   * @param element          WebElement to wait for
-   * @param timeoutInSeconds timeout
-   * @return WebElement
-   */
-  public static WebElement waitForElementToBeClickable(WebElement element, long timeoutInSeconds) {
-    logger.info("Waiting for the element: " + element + " to be clickable " +
-      "with the timeout: " + timeoutInSeconds + " seconds");
-    return SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.elementToBeClickable(element));
-  }
-
-  /**
-   * Wait for element to be clickable within the Default timeout: {@link ConstantsUtil#DEFAULT_TIMEOUT_SECONDS}
-   *
-   * @param element WebElement to wait for
-   * @return WebElement
-   */
-  public static WebElement waitForElementToBeClickable(WebElement element) {
-    return waitForElementToBeClickable(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
-  }
-
-  /**
-   * Wait for element to be hidden within the specified timeout
-   *
-   * @param element          WebElement to wait for
-   * @param timeoutInSeconds timeout
-   */
-  public static void waitForElementToBeHidden(WebElement element, long timeoutInSeconds) {
-    logger.info("Waiting for the element: " + element + " to be hidden " +
-      "with the timeout: " + timeoutInSeconds + " seconds");
-    try {
-      SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.invisibilityOf(element));
-    } catch (NoSuchElementException e) {
-      logger.info("Element is not displayed");
+    /**
+     * Wait for element to be present
+     *
+     * @param locator locator of the element
+     * @return WebElement
+     */
+    public static WebElement waitForElementToBePresent(By locator) {
+        logger.info("Waiting for the element: " + locator + " to be present " +
+                "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
+        return SeleniumDriver.getWaitDriver().until(ExpectedConditions.presenceOfElementLocated(locator));
     }
-  }
 
-  /**
-   * Wait for element to be hidden within the Default timeout: {@link ConstantsUtil#DEFAULT_TIMEOUT_SECONDS}
-   *
-   * @param element WebElement to wait for
-   */
-  public static void waitForElementToBeHidden(WebElement element) {
-    waitForElementToBeHidden(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
-  }
+    /**
+     * Wait for element to be optionally present
+     *
+     * @param locator locator of the element
+     * @return WebElement
+     */
+    public static boolean waitForElementToBeOptionallyPresent(By locator, long timeoutInSeconds) {
+        logger.info("Waiting for the element: " + locator + " to be optionally present " +
+                "with the timeout: " + timeoutInSeconds + " seconds");
+        boolean flag = false;
 
-  /**
-   * Wait for element to be hidden within the specified timeout
-   *
-   * @param locator          WebElement to wait for
-   * @param timeoutInSeconds timeout
-   */
-  public static void waitForElementToBeHidden(By locator, long timeoutInSeconds) {
-    logger.info("Waiting for the element: " + locator + " to be hidden " +
-      "with the timeout: " + timeoutInSeconds + " seconds");
-    try {
-      SeleniumDriver.getWaitDriver(timeoutInSeconds)
-        .until(ExpectedConditions.invisibilityOf(SeleniumDriver.getDriver().findElement(locator)));
-    } catch (NoSuchElementException e) {
-      logger.info("Element is not displayed");
+        try {
+            SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.presenceOfElementLocated(locator));
+            flag = true;
+            return flag;
+        } catch (Exception e) {
+            logger.info("Element: " + locator + " is not present");
+            return flag;
+        }
     }
-  }
 
-  /**
-   * Wait for element to be selected
-   *
-   * @param element WebElement to wait for
-   * @return WebElement
-   */
-  public static boolean waitForElementToBeSelected(WebElement element) {
-    logger.info("Waiting for the element: " + element + " to be selected " +
-      "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
-    return SeleniumDriver.getWaitDriver().until(ExpectedConditions.elementSelectionStateToBe(element, true));
-  }
+    /**
+     * Wait for element to be displayed within the specified timeout
+     *
+     * @param element          WebElement to wait for
+     * @param timeoutInSeconds timeout
+     * @return WebElement
+     */
+    public static WebElement waitForElementToBeDisplayed(WebElement element, long timeoutInSeconds) {
+        logger.info("Waiting for the element: " + element + " to be displayed " +
+                "with the timeout: " + timeoutInSeconds + " seconds");
+        return SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.visibilityOf(element));
+    }
 
-  /**
-   * Waiting for the new window to open
-   *
-   * @param expectedTotalNumberOfWindows 2 or more
-   */
-  public static void waitForNewWindow(int expectedTotalNumberOfWindows) {
-    logger.info("Waiting for the New Window. Expected windows count: " + expectedTotalNumberOfWindows);
-    SeleniumDriver.getWaitDriver().until(ExpectedConditions.numberOfWindowsToBe(expectedTotalNumberOfWindows));
-  }
+    /**
+     * Wait for element to be displayed within the Default timeout: {@link ConstantsUtil#DEFAULT_TIMEOUT_SECONDS}
+     *
+     * @param element WebElement to wait for
+     * @return WebElement
+     */
+    public static WebElement waitForElementToBeDisplayed(WebElement element) {
+        return waitForElementToBeDisplayed(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
+    }
 
-  /**
-   * Wait for element to be enabled
-   *
-   * @param element WebElement to wait for
-   */
-  public static void waitForElementToBeEnabled(WebElement element) {
-    waitForElementToBeEnabled(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
-  }
+    /**
+     * Wait for element to be displayed without failing, if the element does not get displayed
+     *
+     * @param locator          Locator of the WebElement
+     * @param timeoutInSeconds timeout
+     */
+    public static boolean waitForElementToBeOptionallyDisplayed(By locator, long timeoutInSeconds) {
+        logger.info("Waiting for the element: " + locator.toString() + " to be optionally displayed " +
+                "with the timeout: " + timeoutInSeconds + " seconds");
 
-  /**
-   * @param element          WebElement to wait for
-   * @param timeoutInSeconds timeout
-   */
-  public static void waitForElementToBeEnabled(WebElement element, long timeoutInSeconds) {
-    ExpectedCondition<Boolean> elementToBeEnabled = new ExpectedCondition<Boolean>() {
-      @Override
-      public @Nullable Boolean apply(@Nullable WebDriver webDriver) {
-        return element.isEnabled();
-      }
+        try {
+            SeleniumDriver.getWaitDriver(timeoutInSeconds)
+                    .until(ExpectedConditions.visibilityOf(SeleniumDriver.getDriver().findElement(locator)));
+            return true;
+        } catch (NoSuchElementException e) {
+            logger.info("Element is not displayed");
+            return false;
+        } catch (StaleElementReferenceException e) {
+            logger.info("Element is not interactable");
+            return false;
+        }
+    }
 
-      public String toString() {
-        return "element to be enabled: " + element;
-      }
-    };
+    /**
+     * Wait for element to be clickable within the specified timeout
+     *
+     * @param element          WebElement to wait for
+     * @param timeoutInSeconds timeout
+     * @return WebElement
+     */
+    public static WebElement waitForElementToBeClickable(WebElement element, long timeoutInSeconds) {
+        logger.info("Waiting for the element: " + element + " to be clickable " +
+                "with the timeout: " + timeoutInSeconds + " seconds");
+        return SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.elementToBeClickable(element));
+    }
 
-    logger.info("Waiting for the element: " + element + " to be enabled " +
-      "with the timeout: " + timeoutInSeconds + " seconds");
-    SeleniumDriver.getWaitDriver(timeoutInSeconds).until(elementToBeEnabled);
-  }
+    /**
+     * Wait for element to be clickable within the Default timeout: {@link ConstantsUtil#DEFAULT_TIMEOUT_SECONDS}
+     *
+     * @param element WebElement to wait for
+     * @return WebElement
+     */
+    public static WebElement waitForElementToBeClickable(WebElement element) {
+        return waitForElementToBeClickable(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
+    }
 
-  /**
-   * Wait for text to be present in element's value attribute
-   *
-   * @param element WebElement to check text
-   * @param text    text to check in value attribute of the element
-   */
-  public static boolean waitForTextToBePresentInElementValue(WebElement element, String text) {
-    logger.info("Waiting for the element: " + element + " to contain value: " + text +
-                  " with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
-    return SeleniumDriver.getWaitDriver().until(ExpectedConditions.textToBePresentInElementValue(element, text));
-  }
+    /**
+     * Wait for element to be hidden within the specified timeout
+     *
+     * @param element          WebElement to wait for
+     * @param timeoutInSeconds timeout
+     */
+    public static void waitForElementToBeHidden(WebElement element, long timeoutInSeconds) {
+        logger.info("Waiting for the element: " + element + " to be hidden " +
+                "with the timeout: " + timeoutInSeconds + " seconds");
+        try {
+            SeleniumDriver.getWaitDriver(timeoutInSeconds).until(ExpectedConditions.invisibilityOf(element));
+        } catch (NoSuchElementException e) {
+            logger.info("Element is not displayed");
+        } catch (TimeoutException e) {
+            logger.info("Element is not displayed within the timeout: " + timeoutInSeconds);
+        }
+    }
+
+    /**
+     * Wait for element to be hidden within the Default timeout: {@link ConstantsUtil#DEFAULT_TIMEOUT_SECONDS}
+     *
+     * @param element WebElement to wait for
+     */
+    public static void waitForElementToBeHidden(WebElement element) {
+        waitForElementToBeHidden(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * Wait for element to be hidden within the specified timeout
+     *
+     * @param locator          WebElement to wait for
+     * @param timeoutInSeconds timeout
+     */
+    public static void waitForElementToBeHidden(By locator, long timeoutInSeconds) {
+        logger.info("Waiting for the element: " + locator + " to be hidden " +
+                "with the timeout: " + timeoutInSeconds + " seconds");
+        try {
+            SeleniumDriver.getWaitDriver(timeoutInSeconds)
+                    .until(ExpectedConditions.invisibilityOf(SeleniumDriver.getDriver().findElement(locator)));
+        } catch (NoSuchElementException e) {
+            logger.info("Element is not displayed");
+        }
+    }
+
+    /**
+     * Wait for element to be selected
+     *
+     * @param element WebElement to wait for
+     * @return WebElement
+     */
+    public static boolean waitForElementToBeSelected(WebElement element) {
+        logger.info("Waiting for the element: " + element + " to be selected " +
+                "with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
+        return SeleniumDriver.getWaitDriver().until(ExpectedConditions.elementSelectionStateToBe(element, true));
+    }
+
+    /**
+     * Waiting for the new window to open
+     *
+     * @param expectedTotalNumberOfWindows 2 or more
+     */
+    public static void waitForNewWindow(int expectedTotalNumberOfWindows) {
+        logger.info("Waiting for the New Window. Expected windows count: " + expectedTotalNumberOfWindows);
+        SeleniumDriver.getWaitDriver().until(ExpectedConditions.numberOfWindowsToBe(expectedTotalNumberOfWindows));
+    }
+
+    /**
+     * Wait for element to be enabled
+     *
+     * @param element WebElement to wait for
+     */
+    public static void waitForElementToBeEnabled(WebElement element) {
+        waitForElementToBeEnabled(element, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * @param element          WebElement to wait for
+     * @param timeoutInSeconds timeout
+     */
+    public static void waitForElementToBeEnabled(WebElement element, long timeoutInSeconds) {
+        ExpectedCondition<Boolean> elementToBeEnabled = new ExpectedCondition<Boolean>() {
+            @Override
+            public @Nullable Boolean apply(@Nullable WebDriver webDriver) {
+                return element.isEnabled();
+            }
+
+            public String toString() {
+                return "element to be enabled: " + element;
+            }
+        };
+
+        logger.info("Waiting for the element: " + element + " to be enabled " +
+                "with the timeout: " + timeoutInSeconds + " seconds");
+        SeleniumDriver.getWaitDriver(timeoutInSeconds).until(elementToBeEnabled);
+    }
+
+    /**
+     * Wait for text to be present in element's value attribute
+     *
+     * @param element WebElement to check text
+     * @param text    text to check in value attribute of the element
+     */
+    public static boolean waitForTextToBePresentInElementValue(WebElement element, String text) {
+        logger.info("Waiting for the element: " + element + " to contain value: " + text +
+                " with the Default timeout: " + ConstantsUtil.DEFAULT_TIMEOUT_SECONDS + " seconds");
+        return SeleniumDriver.getWaitDriver().until(ExpectedConditions.textToBePresentInElementValue(element, text));
+    }
 }

--- a/src/main/java/io/cdap/e2e/utils/WaitHelper.java
+++ b/src/main/java/io/cdap/e2e/utils/WaitHelper.java
@@ -138,6 +138,9 @@ public class WaitHelper {
         } catch (StaleElementReferenceException e) {
             logger.info("Element is not interactable");
             return false;
+        } catch (TimeoutException e) {
+            logger.info("Element not found withing timeout");
+            return false;
         }
     }
 

--- a/src/main/java/stepsdesign/PipelineSteps.java
+++ b/src/main/java/stepsdesign/PipelineSteps.java
@@ -24,7 +24,9 @@ import io.cdap.e2e.pages.locators.CdfStudioLocators;
 import io.cdap.e2e.utils.CdfHelper;
 import io.cdap.e2e.utils.ConstantsUtil;
 import io.cdap.e2e.utils.PluginPropertyUtils;
+import io.cdap.e2e.utils.SeleniumDriver;
 import io.cdap.e2e.utils.SeleniumHelper;
+import io.cdap.e2e.utils.WaitHelper;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -36,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -104,6 +107,7 @@ public class PipelineSteps implements CdfHelper {
 
   @Then("Verify plugin: {string} node is displayed on the canvas with a timeout of {long} seconds")
   public void verifyPluginNodeIsDisplayedOnTheCanvas(String pluginName, long timeoutInSeconds) {
+    SeleniumDriver.getDriver().manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
     CdfStudioActions.verifyPluginNodeIsDisplayedOnCanvas(pluginName, timeoutInSeconds);
   }
 
@@ -275,13 +279,13 @@ public class PipelineSteps implements CdfHelper {
   }
 
   @Then("Enter runtime argument value {string} for key {string}")
-  public void enterRuntimeArgumentValueForKey(String value, String runtimeArgumentKey) {
+  public void enterRuntimeArgumentValueForKey(String value, String runtimeArgumentKey) throws InterruptedException {
     CdfStudioActions.enterRuntimeArgumentValue(runtimeArgumentKey, PluginPropertyUtils.pluginProp(value));
   }
 
   @Then("Enter runtime argument value from environment variable {string} for key {string}")
   public void enterRuntimeArgumentValueFromEnvironmentVariableForKey(String envVariableKey,
-                                                                     String runtimeArgumentKey) {
+                                                       String runtimeArgumentKey) throws InterruptedException {
     CdfStudioActions.enterRuntimeArgumentValue(runtimeArgumentKey,
       System.getenv(PluginPropertyUtils.pluginProp(envVariableKey)));
   }
@@ -317,7 +321,7 @@ public class PipelineSteps implements CdfHelper {
   }
 
   @Then("Verify the preview run status of pipeline in the logs is {string}")
-  public void verifyThePreviewRunStatusOfOfPipelineInTheLogsIs(String previewStatus) {
+  public void verifyThePreviewRunStatusOfOfPipelineInTheLogsIs(String previewStatus) throws InterruptedException {
     CdfStudioActions.verifyPipelinePreviewStatusInLogs(previewStatus);
   }
 
@@ -733,7 +737,7 @@ public class PipelineSteps implements CdfHelper {
   }
 
   @Then("Select the file for importing the pipeline for the plugin {string}")
-  public void selectFileForImport(String path) throws URISyntaxException {
+  public void selectFileForImport(String path) throws URISyntaxException, InterruptedException {
     CdfStudioActions.importPipeline(PluginPropertyUtils.pluginProp(path));
   }
 


### PR DESCRIPTION
Objective: Refresh the pipeline run page if the status of the pipeline is stuck on UI. This is a workaround till the UI issue is fixed. 

Summary of the changes:
- Updated the "waitTillPipelineRunCompletes()" function for the page refresh
- WaitHelper.waitForElementToBeHidden() has been fixed with try-catch block