### PR TITLE
OSSRH to central sonatype repo migration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,18 @@ the License.-->
   <distributionManagement>
     <repository>
       <id>sonatype.release</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
       <id>sonatype.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
   
   <repositories>
     <repository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/groups/public</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -71,7 +71,7 @@ the License.-->
     </repository>
     <repository>
       <id>sonatype-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repositories/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -275,7 +275,7 @@ the License.-->
             <version>1.6.14</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://oss.sonatype.org</nexusUrl>
+              <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
               <serverId>sonatype.release</serverId>
             </configuration>
           </plugin>


### PR DESCRIPTION
* Updating the releases and snapshot urls. This will allow us to use existing plugins and push to the new central repository.