### PR TITLE
Use central-publishing-maven-plugin for deploy.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Check if version already exists in Maven Central
         id: check_maven
-        working-directory: e2e
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
     

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,10 +70,8 @@ jobs:
           echo "Checking if artifact exists: $URL"
     
           if curl --silent --fail --head "$URL"; then
-           echo "artifact exists"
            echo "exists=true" >> $GITHUB_OUTPUT
           else
-           echo "artifact does not exists"
            echo "exists=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
     
-          URL="https://repo1.maven.org/maven2/io/cdap/tests/e2e/cdap-e2e-framework/${VERSION}/"
+          URL="https://repo1.maven.org/maven2/io.cdap.tests.e2e/cdap-e2e-framework/${VERSION}/"
           echo "Checking if artifact exists: $URL"
     
           if curl --silent --fail --head "$URL"; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,22 +61,7 @@ jobs:
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
           echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
 
-      - name: Check if version already exists in Maven Central
-        id: check_maven
-        run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-    
-          URL="https://repo1.maven.org/maven2/io.cdap.tests.e2e/cdap-e2e-framework/${VERSION}/"
-          echo "Checking if artifact exists: $URL"
-    
-          if curl --silent --fail --head "$URL"; then
-           echo "exists=true" >> $GITHUB_OUTPUT
-          else
-           echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Build and Deploy
-        if: steps.check_maven.outputs.exists == 'false'
         working-directory: e2e
         run: mvn -B -V -DskipTests clean deploy -P release -Dgpg.passphrase=$CDAP_GPG_PASSPHRASE -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -47,28 +47,7 @@ the License.-->
     <tag>HEAD</tag>
   </scm>
 
-  <distributionManagement>
-    <repository>
-      <id>sonatype.release</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>sonatype.snapshots</id>
-      <url>https://central.sonatype.com/repository/maven-snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-  
   <repositories>
-    <repository>
-      <id>sonatype</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/content/groups/public</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
     <repository>
       <id>sonatype-snapshots</id>
       <url>https://central.sonatype.com/repository/maven-snapshots</url>
@@ -256,27 +235,14 @@ the License.-->
           </plugin>
 
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <version>2.5.3</version>
-            <configuration>
-              <tag>v${releaseVersion}</tag>
-              <tagNameFormat>v@{project.version}</tagNameFormat>
-              <autoVersionSubmodules>true</autoVersionSubmodules>
-              <!-- releaseProfiles configuration will actually force a Maven profile
-                – the `releases` profile – to become active during the Release process. -->
-              <releaseProfiles>releases</releaseProfiles>
-            </configuration>
-          </plugin>
-
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.14</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
-              <serverId>sonatype.release</serverId>
+              <publishingServerId>sonatype.release</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <ignorePublishedComponents>true</ignorePublishedComponents>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
* Using the central-publishing-maven-plugin to release the changes.
* Distribution management tag is no longer required with this plugin.
* sonatype repository can be removed since we are pulling from central.
* sonatype-snapshots pointed to https://central.sonatype.com/repository/maven-snapshots. This was done as part of the last PR.