### PR TITLE
Fix driver version

### DIFF
--- a/src/main/scripts/driver_details.yaml
+++ b/src/main/scripts/driver_details.yaml
@@ -23,7 +23,7 @@ modules:
     url: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/releases/download/v1.0.16/mysql-socket-factory-connector-j-8-1.0.16-jar-with-driver-and-dependencies.jar
     driver_prop: '[{"name":"cloudsql-mysql","type":"jdbc","className":"com.mysql.jdbc.Driver","description":"Plugin for the CloudSQL MySQL JDBC driver"}]'
     artifact_name: 'cloudsql-mysql-plugin'
-    artifact_version: '8-1.0.16-jar-with-driver-and-dependencies'
+    artifact_version: '1.0.16-jar-with-driver-and-dependencies'
   cloudsql-postgresql-plugin:
     url: https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory/releases/download/v1.0.16/postgres-socket-factory-1.0.16-jar-with-driver-and-dependencies.jar
     driver_prop: '[{"name":"cloudsql-postgresql","type":"jdbc","className":"org.postgresql.Driver","description":"Plugin for the CloudSQL PostgreSQL JDBC driver"}]'


### PR DESCRIPTION
```
Installing cloudsql-mysql-plugin driver
The suffix of the version is not valid. It should contain only alphanumeric characters and hyphen(-)
```