### PR TITLE
Add exit gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-# Copyright © 2022 Cask Data, Inc.
+# Copyright © 2025 Cask Data, Inc.
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
 #  the License at
@@ -25,16 +25,6 @@ jobs:
 
     steps:
 
-      - name: Get Secrets from GCP Secret Manager
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v0'
-        with:
-          secrets: |-
-            CDAP_OSSRH_USERNAME:cdapio-github-builds/CDAP_OSSRH_USERNAME
-            CDAP_OSSRH_PASSWORD:cdapio-github-builds/CDAP_OSSRH_PASSWORD
-            CDAP_GPG_PASSPHRASE:cdapio-github-builds/CDAP_GPG_PASSPHRASE
-            CDAP_GPG_PRIVATE_KEY:cdapio-github-builds/CDAP_GPG_PRIVATE_KEY
-
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
@@ -49,23 +39,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-cdap-e2e-framework
 
-      - name: Import GPG key
+      - name: Submit Build to GCB
+        id: gcb
+        working-directory: cdap-e2e-tests
         run: |
-          echo "$GPG_PRIVATE_KEY" > private.key
-          gpg --import --batch private.key
-        env:
-          GPG_PRIVATE_KEY: ${{ steps.secrets.outputs.CDAP_GPG_PRIVATE_KEY }}
+          gcloud builds submit . \
+            --config=cloudbuild.yaml \
+            --project='cdapio-github-builds' \
 
-      - name: Set up GPG conf
-        run: |
-          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
-          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-
-      - name: Build and Deploy
-        working-directory: e2e
-        run: mvn -B -V -DskipTests clean deploy -P release -Dgpg.passphrase=$CDAP_GPG_PASSPHRASE -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
-        env:
-          CDAP_OSSRH_USERNAME: ${{ steps.secrets.outputs.CDAP_OSSRH_USERNAME }}
-          CDAP_OSSRH_PASSWORD: ${{ steps.secrets.outputs.CDAP_OSSRH_PASSWORD }}
-          CDAP_GPG_PASSPHRASE: ${{ steps.secrets.outputs.CDAP_GPG_PASSPHRASE }}
-          MAVEN_OPTS: '-Xmx3200m'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,67 @@
+# Copyright © 2025 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+steps:
+  - name: 'gcr.io/cloud-builders/mvn:3.8-jdk-8'
+    id: maven-package
+    entrypoint: 'mvn'
+    args:
+      - -B
+      - -U
+      - clean
+      - package
+      - -DskipTests
+
+  - name: 'gcr.io/cloud-builders/mvn:3.8-jdk-8'
+    id: deploy-to-artifact-registry
+    entrypoint: 'mvn'
+    args:
+      - 'deploy'
+      - '-DskipTests'
+      - '-Dmaven.wagon.http.google.EffectiveVersion=1.0.1'
+    waitFor: ['maven-package']
+
+  - name: 'bash'
+    id: create-exit-gate-manifest
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -e
+        MANIFEST_FILE="/workspace/exit_gate_manifest.textproto"
+        echo '# -*- protobuffer -*-' > "$${MANIFEST_FILE}"
+        echo '# proto-file: security/opensource/exit_gate_v1/onboarded/proto/publishing_manifest.proto' >> "$${MANIFEST_FILE}"
+        echo '# proto-message: PublishingManifest' >> "$${MANIFEST_FILE}"
+        echo '' >> "$${MANIFEST_FILE}"
+        echo 'publish_all: true' >> "$${MANIFEST_FILE}"
+        echo "Created manifest file: $${MANIFEST_FILE}"
+    waitFor: ['deploy-to-artifact-registry']
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: upload-exit-gate-manifest
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -e
+        GCS_MANIFEST_DIR="gs://oss-exit-gate-prod-projects-bucket/cloud-data-fusion/mavencentral/manifests/"
+        MANIFEST_FILE="/workspace/exit_gate_manifest.textproto"
+        # Use a timestamp to create a unique manifest filename for each release
+        MANIFEST_FILENAME="release_$(date -u +%Y%m%d%H%M%S).textproto"
+
+        echo "Uploading manifest to $${GCS_MANIFEST_DIR}$${MANIFEST_FILENAME}"
+        gsutil cp "$${MANIFEST_FILE}" "$${GCS_MANIFEST_DIR}$${MANIFEST_FILENAME}"
+        echo "Manifest uploaded successfully. OSS Exit Gate process should now be triggered."
+    waitFor: ['create-exit-gate-manifest']
+
+options:
+  requestedVerifyOption: VERIFIED
+  machineType: 'E2_HIGHCPU_32'

--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,23 @@ the License.-->
     <tag>HEAD</tag>
   </scm>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/oss-exit-gate-prod/cloud-data-fusion--mavencentral</url>
+    </snapshotRepository>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-maven.pkg.dev/oss-exit-gate-prod/cloud-data-fusion--mavencentral</url>
+    </repository>
+  </distributionManagement>
+
   <repositories>
     <repository>
-      <id>sonatype-snapshots</id>
-      <url>https://central.sonatype.com/repository/maven-snapshots</url>
+      <id>artifact-registry</id>
+      <url>artifactregistry:us-maven.pkg.dev/oss-exit-gate-prod/cloud-data-fusion--mavencentral</url>
       <releases>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>
@@ -60,12 +71,19 @@ the License.-->
     </repository>
   </repositories>
 
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
+
   <build>
+    <extensions>
+      <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.5</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -215,35 +233,6 @@ the License.-->
                 </goals>
               </execution>
             </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
-            <configuration>
-              <passphrase>${gpg.passphrase}</passphrase>
-              <useAgent>${gpg.useagent}</useAgent>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>sonatype.release</publishingServerId>
-              <autoPublish>false</autoPublish>
-              <ignorePublishedComponents>true</ignorePublishedComponents>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
This change refactors the build process to improve artifact security and provenance.

## Key Changes:

Maven artifact building  and attestations are now performed within GCB.
Release artifacts, and build attestations are staged in a designated bucket.
This new process enhances the security and verifiability of the build supply chain.