### PR TITLE
windowDimensionFix

### DIFF
--- a/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
+++ b/src/main/java/io/cdap/e2e/utils/SeleniumDriver.java
@@ -49,7 +49,7 @@ public class SeleniumDriver {
     ChromeOptions chromeOptions = new ChromeOptions();
     chromeOptions.addArguments("--no-sandbox");
     chromeOptions.addArguments("--disable-setuid-sandbox");
-    chromeOptions.addArguments("--headless");
+    chromeOptions.addArguments("--headless=new");
     chromeOptions.addArguments("--window-size=" + SeleniumHelper.readParameters("windowSize"));
     chromeOptions.addArguments("--disable-gpu");
     chromeOptions.addArguments("--disable-dev-shm-usage");
@@ -62,7 +62,6 @@ public class SeleniumDriver {
     chromePrefs.put("download.default_directory", downloadDir);
     chromeOptions.setExperimentalOption("prefs", chromePrefs);
     chromeDriver = new ChromeDriver(service, chromeOptions);
-    chromeDriver.manage().window().maximize();
     HttpCommandExecutor executor = (HttpCommandExecutor) chromeDriver.getCommandExecutor();
     url = executor.getAddressOfRemoteServer();
     waitDriver = new WebDriverWait(chromeDriver, ConstantsUtil.DEFAULT_TIMEOUT_SECONDS);

--- a/src/main/resources/connectionParameters.properties
+++ b/src/main/resources/connectionParameters.properties
@@ -1,5 +1,5 @@
 # Selenium browser window size
-windowSize=1920x1040
+windowSize=1920,1040
 # CDAP application url
 cdfurl=http://localhost:11011/pipelines/ns/default/studio
 # CDAP Wrangler connections page url


### PR DESCRIPTION
This PR addresses the framework-level issue where the browser window was failing to scale correctly during execution.

**Changes**
**Updated Chrome Headless Mode**: Migrated from the legacy headless argument to --headless=new. This ensures better compatibility with the latest Chrome versions and to ensure consistency.

**Corrected Resolution Format**: Updated the configuration file to define screen dimensions using comma-separated values (1920,1080) instead of the 1920X1080 format to align with framework parsing requirements.

Removed the maximize() call. Since the window size is now correctly defined via config

